### PR TITLE
Add copyright file and some additional fields to the control file for Debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src/CedilleParser.hs
 *.cedille
 *.racket
 *.*~
+cedille-deb-pkg
+cedille-deb-pkg.deb

--- a/Makefile
+++ b/Makefile
@@ -147,11 +147,13 @@ cedille-deb-pkg: cedille-static
 	cp -R ./cedille-mode/ ./cedille-mode.el ./se-mode/ ./cedille-deb-pkg/usr/share/emacs/site-lisp/
 	cp ./cedille-static ./cedille-deb-pkg/usr/bin/cedille
 	cp ./cedille-deb-control ./cedille-deb-pkg/DEBIAN/control
+	cp ./cedille-deb-copyright ./cedille-deb-pkg/DEBIAN/copyright
 	dpkg-deb --build cedille-deb-pkg
 	rm -R cedille-deb-pkg
 
 clean:
 	rm -f cedille $(SRCDIR)/main $(OBJ); cd parser; make clean
+	rm -rf cedille-deb-pkg
 
 #lines:
 #	wc -l $(AGDASRC:%=$(SRCDIR)//%) $(GRAMMARS:%=$(SRCDIR)//%) $(CEDILLE_ELISP)

--- a/cedille-deb-control
+++ b/cedille-deb-control
@@ -2,4 +2,26 @@ Package: cedille
 Version: 1.0.0
 Maintainer: Cedille Development Team, The University of Iowa <aaron-stump@uiowa.edu>
 Architecture: all
-Description: Cedille Debian package
+Homepage: https://cedille.github.io/
+#Vcs-Browser: https://github.com/cedille/cedille
+#Vcs-Git: https://github.com/cedille/cedille.git
+Description: Cedille is a dependently typed programming language.
+ Cedille is an interactive theorem-prover and dependently typed programming language, based on extrinsic
+ (aka Curry-style) type theory. This makes it rather different from type theories like Coq and Agda, which are intrinsic
+ (aka Church-style). In Cedille, terms are nothing more than annotated versions of terms of pure untyped lambda
+ calculus. In contrast, in Coq or Agda, the various typing annotations one writes are intrinsic parts of terms, and can
+ be erased, if at all, only as an optimization under certain conditions, not in virtue of the definition of the
+ type theory.
+ .
+ Cedille’s type theory allows one to derive inductive datatypes, together with their induction principles. These
+ derivations are done via lambda-encodings, including not just the familiar Church encoding (with its well-known
+ limitation to inefficient accessors), but also more efficient Parigot and Mendler encodings. The planned 1.1 version
+ of Cedille will support datatype declarations and pattern-matching recursion, via elaboration to certain of these
+ encodings. (This feature did not quite make it into the 1.0 release.)
+ .
+ Cedille is used from an emacs mode, which communicates with the backend tool. The emacs mode supports convenient
+ navigation of the source text following the structure of its syntax tree. Typing and context information is available
+ for all subexpressions as one navigates, as well as information related to type inference. Cedille implements a novel
+ form of local type inference called spine-local type inference. At the moment this is restricted to solving for
+ first-order type variables, but in the coming 2018-2019 academic year we plan to add support for inferring values for
+ term variables as well as dependent and higher-order type variables.

--- a/cedille-deb-copyright
+++ b/cedille-deb-copyright
@@ -1,0 +1,19 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: cedille
+Source: https://github.com/cedille/cedille.git
+
+Files: *
+Copyright: 2018 The University of Iowa
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ persons to whom the Software is furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
The current situation with debian packaging is still mostly a hack (it's too low level, we shouldn't be using dpkg-deb directly). Ultimately, we should build a source package, but that's not really necessary on short notice and not until we want the package to actually be in Debian's package list.

I made this a pull request so you guys could take a look and accept / reject the changes instead of me pushing to master. Especially since I don't really know the project all that well at all at the moment!