### PR TITLE
IAL submodule and bootstrap script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.dyn_hi
 MAlonzo
 cedille
-ial
 libraries
 src/CedilleCommentsLexer.hs
 src/CedilleLexer.hs

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/CedilleLexer.hs
 src/CedilleOptionsLexer.hs
 src/CedilleOptionsParser.hs
 src/CedilleParser.hs
+src/templates/TemplatesCompiler
 *.cedille
 *.racket
 *.*~

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cedille-mac-pkg
 *.bbl
 *.blg
 *.log
+*.elc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ial"]
 	path = ial
-	url = git@github.com:cedille/ial.git
+	url = ../ial.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ial"]
+	path = ial
+	url = git@github.com:cedille/ial.git

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ OBJ = $(SRC:%.agda=%.agdai)
 
 LIB = --library-file=libraries --library=ial --library=cedille
 
-all: cedille # elisp
+all: cedille elisp
 
 libraries: ./ial/ial.agda-lib
 	./create-libraries.sh
@@ -120,12 +120,8 @@ cedille-old:	$(SRC) Makefile libraries
 		$(AGDA) $(LIB) --ghc-flag=-rtsopts -c $(SRCDIR)/main-old.agda
 		mv $(SRCDIR)/main-old cedille
 
-# compilation of elisp not working
-#
-#elisp: $(SE_MODE:%.el=%.elc) $(ELISP:%.el=%.elc)
-#
-#%.elc: %.el
-#	emacs --batch -L se-mode -L cedille-mode -f batch-byte-compile $<
+elisp:
+	emacs --batch --quick -L . -L se-mode -L cedille-mode --eval '(byte-recompile-directory "." 0)'
 
 cedille-prof:	$(SRC) Makefile
 		$(AGDA) $(LIB) --ghc-flag=-rtsopts --ghc-flag=-prof --ghc-flag=-fprof-auto -c $(SRCDIR)/main.agda
@@ -175,14 +171,7 @@ cedille-mac-pkg: cedille
 	cd ./cedille-mac-pkg && appdmg appdmg.json Cedille.dmg
 
 clean:
-	rm -f cedille $(SRCDIR)/main $(OBJ); cd parser; make clean
-	rm -rf cedille-deb-pkg
-	rm -f src/*.hi src/*.o
-
-realclean: clean
-	rm -rf ial/*
-	rm -f $(TEMPLATESDIR)/TemplatesCompiler
-
+	git clean -Xfd # only remove .gitignore files and directories
 
 #lines:
 #	wc -l $(AGDASRC:%=$(SRCDIR)//%) $(GRAMMARS:%=$(SRCDIR)//%) $(CEDILLE_ELISP)

--- a/cedille-mode.el
+++ b/cedille-mode.el
@@ -29,7 +29,7 @@
   (cedille-platform-case
    "cedille"
    nil
-   "/usr/bin/cedille"
+   "cedille"
    (concat (file-name-as-directory cedille-path) "cedille")))
 
 (defvar cedille-path-el

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -31,6 +31,15 @@ if [ -z "$(which cabal)" ]; then
     fi
 fi
 
+if [ "$(uname -s)" = "Darwin" ]; then
+    cat <<EOF
+Do you see this error on OSX?
+> clang: error: unknown argument: '-no-pie'
+Try setting "C compiler supports -no-pie" to "NO":
+> https://stackoverflow.com/questions/50386787/cabal-install-gcc-failed-in-phase-c-compiler/50419101#50419101
+EOF
+fi
+
 cabal_install alex
 cabal_install happy
 cabal_install cpphs

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+cabal_install() {
+    # Check if a package is installed, install with cabal if not.
+
+    PACKAGE=$1
+    EXE=${2:-"$PACKAGE"}
+    if ! ([ -x "$(command -v $EXE)" ] ||
+	      [ -n "$(cabal exec $EXE -- --version 2>/dev/null)" ]); then
+	echo "Installing $PACKAGE"
+	cabal install "$PACKAGE"
+    fi
+}
+
+if [ -z "$(which cabal)" ]; then
+    echo Installing cabal
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+	brew install cabal-install
+    elif [ -x "$(command -v apt-get)" ]; then
+	sudo apt-get install cabal-install
+    else
+	echo Could not install cabal
+	exit 1
+    fi
+fi
+
+cabal_install alex
+cabal_install happy
+cabal_install cpphs
+cabal_install Agda agda

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -40,7 +40,7 @@ Try setting "C compiler supports -no-pie" to "NO":
 EOF
 fi
 
-cabal_install alex
-cabal_install happy
-cabal_install cpphs
-cabal_install Agda agda
+cabal_install 'alex == 3.2.4' alex
+cabal_install 'happy == 1.19.9' happy
+cabal_install 'cpphs == 1.20.8' cpphs
+cabal_install 'Agda == 2.5.4.*' agda


### PR DESCRIPTION
These are some changes I made while getting it to work on Kubuntu and OSX. IAL is made a submodule, I think this is easier for most people. I also added a bootstrap script. To setup the project is now this easy:

```sh
./script/bootstrap
cabal exec make
```

The bootstrap script would be a good step towards adding CI.

Thoughts?