### PR TITLE
Add colon as opt symbol for triangle

### DIFF
--- a/parser/src/CedilleParser.y
+++ b/parser/src/CedilleParser.y
@@ -59,17 +59,17 @@ import System.Environment
   '>'        { Token $$ (TSym ">") }
   '+'        { Token $$ (TSym "+") }
   '_'        { Token _  (TSym "_") }
-  '.'        { Token $$ (TSym ".") }
-  '('        { Token $$ (TSym "(") }
-  ')'        { Token $$ (TSym ")") }
-  '['        { Token $$ (TSym "[") }
-  ']'        { Token $$ (TSym "]") }
-  ','        { Token $$ (TSym ",") }  
-  '{'        { Token $$ (TSym "{") }
-  '}'        { Token $$ (TSym "}") }
-  ':'        { Token $$ (TSym ":") }
-  'Π'        { Token $$ (TSym "Π") }
-  '∀'        { Token $$ (TSym "∀") }
+  '.'        { Token $$ (TSym ".") }			
+  '('        { Token $$ (TSym "(") }			
+  ')'        { Token $$ (TSym ")") }			
+  '['        { Token $$ (TSym "[") }			
+  ']'        { Token $$ (TSym "]") }			
+  ','        { Token $$ (TSym ",") }			
+  '{'        { Token $$ (TSym "{") }			
+  '}'        { Token $$ (TSym "}") }			
+  ':'        { Token $$ (TSym ":") }			
+  'Π'        { Token $$ (TSym "Π") }			
+  '∀'        { Token $$ (TSym "∀") }			
   'λ'        { Token $$ (TSym "λ") }
   'Λ'        { Token $$ (TSym "Λ") }  
   'ι'        { Token $$ (TSym "ι") }
@@ -129,6 +129,7 @@ Cmd :: { Cmd }
 MaybeCheckType :: { OptType }
                :                        { NoType      }
                | '◂' Type               { SomeType $2 }
+               | ':' Type               { SomeType $2 }
 
 MParams :: { Params }
        :                                { ParamsNil        }
@@ -152,6 +153,7 @@ DataConsts :: { DataConsts }
 DefTermOrType :: { DefTermOrType }
               : var MaybeCheckType '=' Term  { DefTerm (tPosTxt $1) (tTxt $1) $2 $4 }
               | var '◂' Kind       '=' Type  { DefType (tPosTxt $1) (tTxt $1) $3 $5 } 
+              | var ':' Kind       '=' Type  { DefType (tPosTxt $1) (tTxt $1) $3 $5 } 
 
 MDecl :: { Decl }
      : '(' Bvar ':' Tk ')'              { Decl (pos2Txt $1) (tPosTxt $2) NotErased (tTxt $2) $4 (pos2Txt1 $5) }

--- a/parser/test/Tests.hs
+++ b/parser/test/Tests.hs
@@ -94,7 +94,7 @@ test_parser_cmd_str = unlines [
 --  "import ChurchNat ." ,                         
 --  "cNat ◂ ★ = ∀ X : ★ . (X ➔ X) ➔ X ➔ X . " ,
 --  "cZ ◂ cNat = Λ X . λ f . λ a . a.1  . " ,
-    "cS ◂ X ➔ X  = λ n . Λ X . λ f . λ a . f (n · X f a) . "  ,
+    "cS : X ➔ X  = λ n . Λ X . λ f . λ a . f (n · X f a) . "  ,
     " "
   ]
 
@@ -124,7 +124,7 @@ test_parser_cnat_str = unlines [
   ""                                           ,
   "cZ ◂ cNat = Λ X . λ f . λ a . a . "         ,
   ""                                           ,
-  "cS ◂ cNat ➔ cNat = λ n . Λ X . λ f . λ a . f (n · X f a) . ",
+  "cS : cNat ➔ cNat = λ n . Λ X . λ f . λ a . f (n · X f a) . ",
   "{- Multi -   ",
   "    Lines    ",
   "    Comments ",


### PR DESCRIPTION
This adds `:` as  valid symbol in place of the black triangle symbol.

I'm not sure about all use cases of the black triangle, I believe there are some interesting cases with lambdas? I'd like to be informed about that before merging this in.