### PR TITLE
Archive dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ AGDASRC = \
 	cedille-options.agda \
 	elaboration.agda \
 	elaboration-helpers.agda \
-	monad-instances.agda
+	monad-instances.agda \
+	json.agda
 
 CEDILLE_ELISP = \
 		cedille-mode.el \

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ AGDASRC = \
 
 CEDILLE_ELISP = \
 		cedille-mode.el \
+		cedille-mode/cedille-mode-archive.el \
 		cedille-mode/cedille-mode-context.el \
 		cedille-mode/cedille-mode-errors.el \
                 cedille-mode/cedille-mode-faces.el \

--- a/cedille-mode/cedille-mode-archive-template.html
+++ b/cedille-mode/cedille-mode-archive-template.html
@@ -78,13 +78,9 @@
   </head>
   <body>
     <main id="vertical">
-      <div id="cedille-code"><pre><code>%s</code></pre></div>
+      <div id="cedille-code"><pre><code id="cedille-code-block"></code></pre></div>
       <div id="cedille-data"></div>
     </main>
-    <script
-      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-      integrity="sha256-3edrmyuQ0w65f8gfBsqowzjJe2iM6n0nKciPUp8y+7E="
-      crossorigin="anonymous"></script>
     <script type="application/json" id="spans">%s</script>
     <script type="text/javascript">%s</script>
   </body>

--- a/cedille-mode/cedille-mode-archive.el
+++ b/cedille-mode/cedille-mode-archive.el
@@ -22,15 +22,20 @@
     (user-error "Must be using cedille mode!")))
 
 (defun cedille-save-archive ()
-  (let ((archive-file-name (concat (buffer-name) ".html"))
+  (let ((buffer-name (buffer-name))
+        (archive-file-name (concat (buffer-name) ".html"))
         (text (buffer-substring-no-properties (point-min) (point-max)))
         (spans se-mode-spans))
     (with-temp-file archive-file-name
-      (insert (cedille-spans-to-html spans text)))
+      (insert (format cedille-archive-html-template
+                      (cedille-buffer-to-json buffer-name spans text)
+                      cedille-archive-javascript)))
     (message "Saved archive as %s" archive-file-name)))
 
-(defun cedille-spans-to-json (spans)
-  (json-encode (cedille-spans-to-sexp spans)))
+(defun cedille-buffer-to-json (buffer-name spans text)
+  (json-encode
+   `((,buffer-name . ((text . ,text)
+                      (spans . ,(cedille-spans-to-sexp spans)))))))
 
 (defun cedille-spans-to-sexp (spans)
   (mapcar 'cedille-span-to-sexp spans))
@@ -40,21 +45,6 @@
     (start . ,(se-span-start span))
     (end . ,(se-span-end span))
     (data . ,(se-span-data span))))
-
-(defun cedille-spans-to-html (spans text)
-  (let* ((output nil)
-         (index 1))
-    (dolist (char (string-to-list text))
-      (dotimes (_ (cl-count index spans :key 'se-span-end))
-        (push "</span>" output))
-      (dotimes (_ (cl-count index spans :key 'se-span-start))
-        (push "<span class=\"cedille-span\">" output))
-      (push (string char) output)
-      (incf index))
-    (format cedille-archive-html-template
-            (apply 'concat (reverse output))
-            (cedille-spans-to-json spans)
-            cedille-archive-javascript)))
 
 (provide 'cedille-mode-archive)
 

--- a/cedille-mode/cedille-mode-archive.js
+++ b/cedille-mode/cedille-mode-archive.js
@@ -1,15 +1,47 @@
-
-const cedilleSpans = JSON.parse(document.getElementById('spans').innerHTML);
+const cedilleArchive = JSON.parse(document.getElementById('spans').innerHTML);
 const cedilleData = document.getElementById('cedille-data');
-const htmlSpans = [...document.getElementsByClassName('cedille-span')];
+const cedilleCode = document.getElementById('cedille-code-block');
+const emptyNode = document.createTextNode("");
 
-function removeClassFromSpans(className) {
+const removeClassFromSpans = (className, htmlSpans) => {
   htmlSpans.forEach(htmlSpan => htmlSpan.classList.remove(className));
-}
+};
 
-function displayData({name, start, end, data}) {
-  cedilleData.innerHTML = null;
+const spanLength = ({ start, end }) => {
+  return Math.abs(end - start);
+};
 
+const addEventListeners = (span, htmlSpan, htmlSpans) => {
+  htmlSpan.addEventListener('click', () => {
+    removeClassFromSpans('highlight', htmlSpans);
+    htmlSpan.classList.add('highlight');
+    displayData(span);
+  }, { capture: true });
+
+  htmlSpan.addEventListener('mouseover', () => {
+    removeClassFromSpans('hover-highlight', htmlSpans);
+    htmlSpan.classList.add('hover-highlight');
+  }, { capture: true });
+
+  htmlSpan.addEventListener('mouseout', () => {
+    htmlSpan.classList.remove('hover-highlight');
+  });
+};
+
+const createDiv = (className, textOrChildren) => {
+  const node = document.createElement('div');
+  node.className = className;
+
+  if (typeof textOrChildren !== "object") {
+    node.innerText = textOrChildren;
+  } else {
+    textOrChildren.forEach(child => node.appendChild(child));
+  }
+
+  return node;
+};
+
+const displayData = ({name, start, end, data}) => {
   const displayData = {
     name,
     start,
@@ -17,37 +49,36 @@ function displayData({name, start, end, data}) {
     ...data
   };
 
+  cedilleData.innerHTML = null;
   Object.keys(displayData).forEach((key) => {
-    var bodyDiv = document.createElement('div');
-    var keyDiv = document.createElement('div');
-    var valueDiv = document.createElement('div');
-
-    keyDiv.innerText = key;
-    keyDiv.className = 'cedille-key';
-
-    valueDiv.innerText = displayData[key];
-    valueDiv.className = 'cedille-value';
-
-    bodyDiv.className = 'cedille-pair';
-    bodyDiv.appendChild(keyDiv);
-    bodyDiv.appendChild(valueDiv);
+    const keyDiv = createDiv('cedille-key', key)
+    const valueDiv = createDiv('cedille-value', displayData[key]);
+    const bodyDiv = createDiv('cedille-pair', [keyDiv, valueDiv]);
     cedilleData.appendChild(bodyDiv);
   });
-}
+};
 
-htmlSpans.forEach((htmlSpan, index) => {
-  htmlSpan.addEventListener('click', () => {
-    removeClassFromSpans('highlight');
-    htmlSpan.classList.add('highlight');
-    displayData(cedilleSpans[index]);
-  }, { capture: true });
+const displayCode = (filename) => {
+  const { spans, text } = cedilleArchive[filename];
+  const nodes = [null, ...text].map(c => document.createTextNode(c));
+  const spansByAscendingLength = spans.sort((a, b) => spanLength(a) - spanLength(b));
+  const htmlSpans = [];
 
-  htmlSpan.addEventListener('mouseover', () => {
-    removeClassFromSpans('hover-highlight');
-    htmlSpan.classList.add('hover-highlight');
-  }, { capture: true });
+  spansByAscendingLength.forEach(span => {
+    const htmlSpan = document.createElement("span");
+    htmlSpan.className = 'cedille-span';
+    htmlSpans.push(htmlSpan);
+    addEventListeners(span, htmlSpan, htmlSpans);
 
-  htmlSpan.addEventListener('mouseout', () => {
-    htmlSpan.classList.remove('hover-highlight');
+    for(let i = span.start; i < span.end; i++) {
+      htmlSpan.appendChild(nodes[i] || emptyNode);
+      nodes[i] = (i === span.start) ? htmlSpan : null;
+    }
   });
-});
+
+  cedilleCode.innerHTML = null;
+  cedilleCode.appendChild(nodes[1]);
+};
+
+const filename = Object.keys(cedilleArchive)[0];
+displayCode(filename);

--- a/cedille-mode/cedille-mode-archive.js
+++ b/cedille-mode/cedille-mode-archive.js
@@ -1,4 +1,4 @@
-const cedilleArchive = JSON.parse(document.getElementById('spans').innerHTML);
+const cedilleArchive = JSON.parse(document.getElementById('spans').innerHTML.replace(/\n/g, "\\n"));
 const cedilleData = document.getElementById('cedille-data');
 const cedilleCode = document.getElementById('cedille-code-block');
 const emptyNode = document.createTextNode("");
@@ -9,6 +9,10 @@ const removeClassFromSpans = (className, htmlSpans) => {
 
 const spanLength = ({ start, end }) => {
   return Math.abs(end - start);
+};
+
+const isArray = x => {
+  return x && typeof x === 'object' && x.length !== null;
 };
 
 const addEventListeners = (span, htmlSpan, htmlSpans) => {
@@ -28,14 +32,18 @@ const addEventListeners = (span, htmlSpan, htmlSpans) => {
   });
 };
 
-const createDiv = (className, textOrChildren) => {
+const createDiv = (className, text, children) => {
   const node = document.createElement('div');
   node.className = className;
 
-  if (typeof textOrChildren !== "object") {
-    node.innerText = textOrChildren;
-  } else {
-    textOrChildren.forEach(child => node.appendChild(child));
+  if (isArray(text)) {
+    node.innerText = text[1];
+  } else if (text) {
+    node.innerText = text;
+  }
+
+  if (children) {
+    children.forEach(child => node.appendChild(child));
   }
 
   return node;
@@ -53,14 +61,17 @@ const displayData = ({name, start, end, data}) => {
   Object.keys(displayData).forEach((key) => {
     const keyDiv = createDiv('cedille-key', key)
     const valueDiv = createDiv('cedille-value', displayData[key]);
-    const bodyDiv = createDiv('cedille-pair', [keyDiv, valueDiv]);
+    const bodyDiv = createDiv('cedille-pair', null, [keyDiv, valueDiv]);
     cedilleData.appendChild(bodyDiv);
   });
 };
 
 const displayCode = (filename) => {
-  const { spans, text } = cedilleArchive[filename];
-  const nodes = [null, ...text].map(c => document.createTextNode(c));
+  const source = cedilleArchive[filename].source;
+  const spans = cedilleArchive[filename].spans.spans.map(([name, start, end, data]) => {
+    return { name, start, end, data };
+  });
+  const nodes = [null, ...source].map(c => document.createTextNode(c));
   const spansByAscendingLength = spans.sort((a, b) => spanLength(a) - spanLength(b));
   const htmlSpans = [];
 

--- a/src/general-util.agda
+++ b/src/general-util.agda
@@ -374,6 +374,11 @@ rope-to-string = flip h "" where
   h (s₁ ⊹⊹ s₂) = h s₁ ∘ h s₂
   h [[ s ]] acc = s ^ acc
 
+𝕃-to-rope : ∀{A : Set} → (A → rope) → string → 𝕃 A → rope
+𝕃-to-rope to-rope sep [] = [[]]
+𝕃-to-rope to-rope sep (x :: []) = to-rope x
+𝕃-to-rope to-rope sep (x :: xs) = to-rope x ⊹⊹ [[ sep ]] ⊹⊹ 𝕃-to-rope to-rope sep xs
+
 putStrLn : string → IO ⊤
 putStrLn str = putStr str >> putStr "\n" -- >> flush
 

--- a/src/json.agda
+++ b/src/json.agda
@@ -1,0 +1,35 @@
+module json where
+
+open import lib
+open import general-util
+
+mutual
+  data json-value : Set where
+    json-null : json-value
+    json-string : string → json-value
+    json-nat : nat → json-value
+    json-array : 𝕃 json-value → json-value
+    json-object : json → json-value
+
+  data json : Set where
+    json-empty : json
+    json-pair : json → string → json-value → json
+
+{-# TERMINATING #-}
+json-to-rope : json → rope
+
+json-value-to-rope : json-value → rope
+json-value-to-rope json-null = [[ "null" ]]
+json-value-to-rope (json-string string) = [[ "\"" ]] ⊹⊹ [[ string ]] ⊹⊹ [[ "\"" ]]
+json-value-to-rope (json-nat nat) = [[ ℕ-to-string nat ]]
+json-value-to-rope (json-array array) = 𝕃-to-rope json-value-to-rope "," array
+json-value-to-rope (json-object json) = json-to-rope json
+
+json-to-rope j = [[ "{" ]] ⊹⊹ rec j ⊹⊹ [[ "}" ]] where
+  pair-to-rope : string → json-value → rope
+  pair-to-rope key value = [[ "\"" ]] ⊹⊹ [[ key ]] ⊹⊹ [[ "\":" ]] ⊹⊹ json-value-to-rope value
+
+  rec : json → rope
+  rec json-empty = [[]]
+  rec (json-pair json-empty key value) = pair-to-rope key value
+  rec (json-pair json key value) = pair-to-rope key value ⊹⊹ [[ "," ]] ⊹⊹ rec json

--- a/src/json.agda
+++ b/src/json.agda
@@ -5,19 +5,39 @@ open import general-util
 
 data json : Set where
   json-null : json
+  json-raw : rope → json
   json-string : string → json
   json-nat : nat → json
   json-array : 𝕃 json → json
   json-object : trie json → json
 
+json-escape-string : string → string
+json-escape-string str = 𝕃char-to-string $ rec $ string-to-𝕃char str where
+  rec : 𝕃 char → 𝕃 char
+  rec [] = []
+  rec ('\b' :: chars) = '\\' :: 'b' :: rec chars
+  rec ('\f' :: chars) = '\\' :: 'f' :: rec chars
+  rec ('\n' :: chars) = '\\' :: 'n' :: rec chars
+  rec ('\r' :: chars) = '\\' :: 'r' :: rec chars
+  rec ('\t' :: chars) = '\\' :: 't' :: rec chars
+  rec ('"'  :: chars) = '\\' :: '"' :: rec chars
+  rec ('\\' :: chars) = '\\' :: '\\' :: rec chars
+  rec (char :: chars) = char :: rec chars
+
 {-# TERMINATING #-}
 json-to-rope : json → rope
 json-to-rope json-null = [[ "null" ]]
-json-to-rope (json-string string) = [[ "\"" ]] ⊹⊹ [[ string ]] ⊹⊹ [[ "\"" ]]
+json-to-rope (json-raw rope) = rope
+json-to-rope (json-string string) = [[ "\"" ]] ⊹⊹ [[ json-escape-string string ]] ⊹⊹ [[ "\"" ]]
 json-to-rope (json-nat nat) = [[ ℕ-to-string nat ]]
 json-to-rope (json-array array) = [[ "[" ]] ⊹⊹ 𝕃-to-rope json-to-rope "," array ⊹⊹ [[ "]" ]]
 json-to-rope (json-object t) = [[ "{" ]] ⊹⊹ 𝕃-to-rope key-to-rope "," (trie-strings t) ⊹⊹ [[ "}" ]] where
   key-to-rope : string → rope
   key-to-rope key with trie-lookup t key
-  ...| just value = [[ "\"" ]] ⊹⊹ [[ key ]] ⊹⊹ [[ "\":" ]] ⊹⊹ json-to-rope value
-  ...| nothing = [[ "\"" ]] ⊹⊹ [[ key ]] ⊹⊹ [[ "\":null" ]] -- shouldn't happen
+  ...| just value = [[ "\"" ]] ⊹⊹ [[ json-escape-string key ]] ⊹⊹ [[ "\":" ]] ⊹⊹ json-to-rope value
+  ...| nothing = [[ "\"" ]] ⊹⊹ [[ json-escape-string key ]] ⊹⊹ [[ "\":null" ]] -- shouldn't happen
+
+json-new : 𝕃 (string × json) → json
+json-new pairs = json-object $ foldr insert empty-trie pairs where
+  insert : string × json → trie json → trie json
+  insert (key , value) trie = trie-insert trie key value

--- a/src/json.agda
+++ b/src/json.agda
@@ -3,33 +3,21 @@ module json where
 open import lib
 open import general-util
 
-mutual
-  data json-value : Set where
-    json-null : json-value
-    json-string : string → json-value
-    json-nat : nat → json-value
-    json-array : 𝕃 json-value → json-value
-    json-object : json → json-value
-
-  data json : Set where
-    json-empty : json
-    json-pair : json → string → json-value → json
+data json : Set where
+  json-null : json
+  json-string : string → json
+  json-nat : nat → json
+  json-array : 𝕃 json → json
+  json-object : trie json → json
 
 {-# TERMINATING #-}
 json-to-rope : json → rope
-
-json-value-to-rope : json-value → rope
-json-value-to-rope json-null = [[ "null" ]]
-json-value-to-rope (json-string string) = [[ "\"" ]] ⊹⊹ [[ string ]] ⊹⊹ [[ "\"" ]]
-json-value-to-rope (json-nat nat) = [[ ℕ-to-string nat ]]
-json-value-to-rope (json-array array) = 𝕃-to-rope json-value-to-rope "," array
-json-value-to-rope (json-object json) = json-to-rope json
-
-json-to-rope j = [[ "{" ]] ⊹⊹ rec j ⊹⊹ [[ "}" ]] where
-  pair-to-rope : string → json-value → rope
-  pair-to-rope key value = [[ "\"" ]] ⊹⊹ [[ key ]] ⊹⊹ [[ "\":" ]] ⊹⊹ json-value-to-rope value
-
-  rec : json → rope
-  rec json-empty = [[]]
-  rec (json-pair json-empty key value) = pair-to-rope key value
-  rec (json-pair json key value) = pair-to-rope key value ⊹⊹ [[ "," ]] ⊹⊹ rec json
+json-to-rope json-null = [[ "null" ]]
+json-to-rope (json-string string) = [[ "\"" ]] ⊹⊹ [[ string ]] ⊹⊹ [[ "\"" ]]
+json-to-rope (json-nat nat) = [[ ℕ-to-string nat ]]
+json-to-rope (json-array array) = [[ "[" ]] ⊹⊹ 𝕃-to-rope json-to-rope "," array ⊹⊹ [[ "]" ]]
+json-to-rope (json-object t) = [[ "{" ]] ⊹⊹ 𝕃-to-rope key-to-rope "," (trie-strings t) ⊹⊹ [[ "}" ]] where
+  key-to-rope : string → rope
+  key-to-rope key with trie-lookup t key
+  ...| just value = [[ "\"" ]] ⊹⊹ [[ key ]] ⊹⊹ [[ "\":" ]] ⊹⊹ json-to-rope value
+  ...| nothing = [[ "\"" ]] ⊹⊹ [[ key ]] ⊹⊹ [[ "\":null" ]] -- shouldn't happen

--- a/src/main.agda
+++ b/src/main.agda
@@ -436,7 +436,7 @@ module main-with-options
               archiveCommand (input :: []) s =
                 canonicalizePath input >>= λ filename →
                 update-asts s filename >>= λ s →
-                process-file progressUpdate s filename (fileBaseName filename) >>= λ { (s , _) →
+                process-file (λ _, _ → return triv) s filename (fileBaseName filename) >>= λ { (s , _) →
                 return (createArchive s filename) >>= λ archive →
                 putRopeLn (json-to-rope archive) >>r s }
               archiveCommand ls s = errorCommand ls s >>r s

--- a/src/main.agda
+++ b/src/main.agda
@@ -419,14 +419,14 @@ module main-with-options
                           input-filename tt {- should-print-spans -}
               checkCommand ls s = errorCommand ls s >>r s
 
-              allDependencies-h : toplevel-state → trie 𝔹 → 𝕃 string → 𝕃 string
-              allDependencies-h s t (filename :: filenames) with get-include-elt-if s filename
-              ...| nothing = allDependencies-h s (trie-insert t filename tt) filenames
-              ...| just ie = allDependencies-h s (trie-insert t filename tt) (filenames ++ include-elt.deps ie)
-              allDependencies-h s t [] = trie-strings t
+              allDependencies-h : toplevel-state → stringset → 𝕃 string → 𝕃 string
+              allDependencies-h s t (filename :: filenames) with stringset-contains t filename | get-include-elt-if s filename
+              ...| ff | just ie = allDependencies-h s (stringset-insert t filename) (filenames ++ include-elt.deps ie)
+              ...| _ | _ = allDependencies-h s t filenames
+              allDependencies-h s t [] = stringset-strings t
 
               allDependencies : toplevel-state → string → 𝕃 string
-              allDependencies s filename = allDependencies-h s empty-trie (filename :: [])
+              allDependencies s filename = allDependencies-h s empty-stringset (filename :: [])
 
               dependenciesCommand : 𝕃 string → toplevel-state → IO toplevel-state
               dependenciesCommand (input :: []) s =

--- a/src/main.agda
+++ b/src/main.agda
@@ -14,7 +14,7 @@ import cws-types
 
 open import constants
 open import general-util
-
+open import json
 
 createOptionsFile : (dot-ced-dir : string) → IO ⊤
 createOptionsFile dot-ced-dir =
@@ -242,10 +242,14 @@ module main-with-options
 
   {- new parser test integration -}
   reparse : toplevel-state → filepath → IO toplevel-state
-  reparse st filename = 
-     doesFileExist filename >>= λ b → 
-       (if b then
-           (readFiniteFile filename >>= λ s → getCurrentTime >>= λ time → processText s >>=r λ ie → set-last-parse-time-include-elt ie time)
+  reparse st filename =
+     doesFileExist filename >>= λ fileExists →
+       (if fileExists then
+           (readFiniteFile filename >>= λ source →
+            getCurrentTime >>= λ time →
+            processText source >>= λ ie →
+            return (set-last-parse-time-include-elt ie time) >>=r λ ie ->
+            set-source-include-elt ie source)
         else return (error-include-elt ("The file " ^ filename ^ " could not be opened for reading.")))
        >>=r set-include-elt st filename
     where processText : string → IO include-elt
@@ -419,21 +423,23 @@ module main-with-options
                           input-filename tt {- should-print-spans -}
               checkCommand ls s = errorCommand ls s >>r s
 
-              allDependencies-h : toplevel-state → stringset → 𝕃 string → 𝕃 string
-              allDependencies-h s t (filename :: filenames) with stringset-contains t filename | get-include-elt-if s filename
-              ...| ff | just ie = allDependencies-h s (stringset-insert t filename) (filenames ++ include-elt.deps ie)
-              ...| _ | _ = allDependencies-h s t filenames
-              allDependencies-h s t [] = stringset-strings t
+              createArchive-h : toplevel-state → trie json → 𝕃 string → json
+              createArchive-h s t (filename :: filenames) with trie-contains t filename | get-include-elt-if s filename
+              ...| ff | just ie = createArchive-h s (trie-insert t filename $ include-elt-to-archive ie) (filenames ++ include-elt.deps ie)
+              ...| _ | _ = createArchive-h s t filenames
+              createArchive-h s t [] = json-object t
 
-              allDependencies : toplevel-state → string → 𝕃 string
-              allDependencies s filename = allDependencies-h s empty-stringset (filename :: [])
+              createArchive : toplevel-state → string → json
+              createArchive s filename = createArchive-h s empty-trie (filename :: [])
 
-              dependenciesCommand : 𝕃 string → toplevel-state → IO toplevel-state
-              dependenciesCommand (input :: []) s =
+              archiveCommand : 𝕃 string → toplevel-state → IO toplevel-state
+              archiveCommand (input :: []) s =
                 canonicalizePath input >>= λ filename →
                 update-asts s filename >>= λ s →
-                putStrLn (𝕃-to-string (λ x → x) (char-to-string delimiter) (allDependencies s filename)) >>r s
-              dependenciesCommand ls s = errorCommand ls s >>r s
+                process-file progressUpdate s filename (fileBaseName filename) >>= λ { (s , _) →
+                return (createArchive s filename) >>= λ archive →
+                putRopeLn (json-to-rope archive) >>r s }
+              archiveCommand ls s = errorCommand ls s >>r s
 
     {-          findCommand : 𝕃 string → toplevel-state → IO toplevel-state
               findCommand (symbol :: []) s = putStrLn (find-symbols-to-JSON symbol (toplevel-state-lookup-occurrences symbol s)) >>= λ x → return s
@@ -446,7 +452,7 @@ module main-with-options
               handleCommands ("debug" :: []) s = debugCommand s >>r s
               handleCommands ("elaborate" :: x :: x' :: []) s = elab-all s x x' >>r s
               handleCommands ("interactive" :: xs) s = interactive-cmds.interactive-cmd options xs s >>r s
-              handleCommands ("dependencies" :: xs) s = dependenciesCommand xs s
+              handleCommands ("archive" :: xs) s = archiveCommand xs s
   --            handleCommands ("find" :: xs) s = findCommand xs s
               handleCommands xs s = errorCommand xs s >>r s
 


### PR DESCRIPTION
To handle dependencies I decided to make Agda generate the archive. This is done via the `archive` command (replaces my previous `dependencies` command). To make this easier I've added `json.agda` and added `source` to the `include-elt` datatype.

This changes several aspects inside the HTML: more spans are displayed, more span data is displayed, and span data is now ordered differently. These will be addressed in follow up PRs. I'll also clean up the messy and non-intuitive parts. I want to merge this PR now to make following PRs small and straight forward.

@HerbertMcSnout Any opinions (the agda code in particular)? My thought is to eventually use the json module for all the JSON output.