### PR TITLE
Cleanup whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ OBJ = $(SRC:%.agda=%.agdai)
 
 LIB = --library-file=libraries --library=ial --library=cedille
 
+.PHONY: all libraries elisp lines elisp-lines agda-lines agda-install whitespace
+
 all: cedille #elisp
 
 libraries: ./ial/ial.agda-lib
@@ -172,3 +174,10 @@ agda-lines:
 
 agda-install:
 	./script/bootstrap
+
+whitespace:
+# add to emacs init: (add-hook 'before-save-hook 'delete-trailing-whitespace)
+	for file in $(SRC) $(ELISP); do \
+		emacs -batch $$file -f delete-trailing-whitespace -f save-buffer & \
+	done
+	wait

--- a/cedille-mode.el
+++ b/cedille-mode.el
@@ -3,8 +3,8 @@
 ;;; Only follow these instruction if you did NOT use the Debian package:
 ;;; You need to set cedille-path to be the path to your Cedille installation.
 ;;; Then add that path to your load path for emacs.
-;;; Then put (require 'cedille-mode) in your .emacs file. 
-;;; 
+;;; Then put (require 'cedille-mode) in your .emacs file.
+;;;
 ;;; For example:
 ;;;
 ;;;    (setq cedille-path "/home/astump/cedille")
@@ -235,7 +235,7 @@ Defaults to `error'."
 (defun cedille-mode-update-buffers()
   "Update the info and context buffers."
   (when cedille-mode-do-update-buffers
-    (cedille-mode-inspect) 
+    (cedille-mode-inspect)
     (cedille-mode-context)
     (cedille-mode-meta-vars)
     (cedille-mode-rebalance-windows)))
@@ -284,7 +284,7 @@ Defaults to `error'."
 (defun cedille-mode-concat-sep (&rest seqs)
   "Concatenates STRS with cedille-mode-sep between each"
   (when seqs (concat (car seqs) (se-foldr (cdr seqs) "" (lambda (h x) (concat cedille-mode-sep h x))))))
-	   
+
 (defun cedille-mode-concat-sep2(sep ss)
   "Concat the strings in nonempty list ss with sep in between each one."
   (let ((he (car ss))
@@ -293,7 +293,7 @@ Defaults to `error'."
       (concat he sep (cedille-mode-concat-sep2 sep ta)))))
 
 (defun cedille-mode-split-string(s)
-  "Return a pair of the prefix of the string up to the first space, 
+  "Return a pair of the prefix of the string up to the first space,
 and the remaining suffix."
   (let ((ss (split-string s " ")))
     (if (< (length ss) 2) s
@@ -312,12 +312,12 @@ is assumed to be a string with a sequence number (prefix up
       (< (string-to-number na) (string-to-number nb))))
 
 (defun cedille-mode-strip-seqnum(s)
-  "Return a new string just like s except without the prefix up to the 
+  "Return a new string just like s except without the prefix up to the
 first space."
   (cdr (cedille-mode-split-string s)))
 
 (defun cedille-mode-sort-and-strip-json(json)
-  "Sort the pairs in the JSON data by the number at the 
+  "Sort the pairs in the JSON data by the number at the
 start of each string, and then strip out that number."
   (when json
       (setq json (sort json 'cedille-mode-compare-seqnums))
@@ -349,7 +349,7 @@ start of each string, and then strip out that number."
      collecting (cons key value)))
 
 (defun cedille-mode-select-next(count)
-  "Selects the next sibling from the currently selected one in 
+  "Selects the next sibling from the currently selected one in
 the parse tree, and updates the Cedille info buffer."
   (interactive "p")
   (if (> count 0)
@@ -360,7 +360,7 @@ the parse tree, and updates the Cedille info buffer."
     (cedille-mode-highlight-occurrences-if)))
 
 (defun cedille-mode-select-previous(count)
-  "Selects the previous sibling from the currently selected one in 
+  "Selects the previous sibling from the currently selected one in
 the parse tree, and updates the Cedille info buffer."
   (interactive "p")
   (if (> count 0)
@@ -444,7 +444,7 @@ Updates info buffer in either case."
     (cedille-mode-select-previous-alt (- count 1))))
 
 (defun cedille-mode-select-parent(count)
-  "Selects the parent of the currently selected node in 
+  "Selects the parent of the currently selected node in
 the parse tree, and updates the Cedille info buffer."
   (interactive "p")
   (if (> count 0)
@@ -543,7 +543,7 @@ in the parse tree, and updates the Cedille info buffer."
 	      (insert new-label))))))))
 
 (defun cedille-mode-highlight-occurrences-if()
-  "If the option is set to highlight matching variable 
+  "If the option is set to highlight matching variable
 occurrences, then do so."
   (cedille-mode-clear-interactive-highlight)
   (when cedille-mode-autohighlight-matching-variables (cedille-mode-highlight-occurrences)))
@@ -781,7 +781,7 @@ occurrences, then do so."
 
   (setq-local se-inf-get-message-from-filename 'cedille-mode-get-message-from-filename)
   (setq-local se-inf-progress-fn 'cedille-mode-progress-fn)
-  (setq-local se-inf-progress-prefix cedille-mode-progress-prefix) 
+  (setq-local se-inf-progress-prefix cedille-mode-progress-prefix)
 
   (set-input-method "Cedille"))
 
@@ -801,7 +801,7 @@ occurrences, then do so."
 		      nil nil nil nil nil nil t) ; maximum-shortest
 
 (mapc (lambda (pair) (quail-defrule (car pair) (cadr pair) "Cedille"))
-	'(("\\l" "λ") ("\\L" "Λ") ("\\>" "→") ("\\r" "➔") ("\\a" "∀") ("\\B" "□") ("\\P" "Π") 
+	'(("\\l" "λ") ("\\L" "Λ") ("\\>" "→") ("\\r" "➔") ("\\a" "∀") ("\\B" "□") ("\\P" "Π")
           ("\\s" "★") ("\\S" "☆") ("\\." "·") ("\\f" "◂") ("\\u" "↑") ("\\p" "φ")
           ("\\h" "●") ("\\k" "𝒌") ("\\i" "ι") ("\\=" "≃") ("\\==" "≅") ("\\d" "δ") ("\\-" "➾")
           ("\\b" "β") ("\\e" "ε") ("\\R" "ρ") ("\\y" "ς") ("\\t" "θ") ("\\x" "χ") ("\\w" "ω")

--- a/cedille-mode/cedille-mode-beta-reduce.el
+++ b/cedille-mode/cedille-mode-beta-reduce.el
@@ -286,7 +286,7 @@
   (let* ((start (se-term-start node))
          (end (min (1+ (buffer-size)) (se-term-end node))))
     (cons (se-get-span node) (buffer-substring start end))))
-  
+
 (defun cedille-mode-br-get-qed (node)
   "Returns the buffer's text from the start to the end of NODE, if it has an error"
   (when (and node (cedille-span-has-error-data (se-term-data node)))

--- a/cedille-mode/cedille-mode-context.el
+++ b/cedille-mode/cedille-mode-context.el
@@ -155,7 +155,7 @@
   "Sorts context according to ordering and stores in cedille-mode-sorted-context-list"
   (let* ((context (copy-sequence cedille-mode-filtered-context-list))
 	 ;; unary predicate for membership in the hidden type/kind list
-	 (hidden-p (lambda (pair) (member pair cedille-mode-hidden-context-tuples))) 
+	 (hidden-p (lambda (pair) (member pair cedille-mode-hidden-context-tuples)))
 	 ;; binary predicate for separating hidden types/kinds
 	 (whiteout (lambda (a b) (and (not (funcall hidden-p a)) (funcall hidden-p b))))
 	 ;; binary predicate for ascending alphabetical order
@@ -246,7 +246,7 @@ which currently consists of:\n
 			 (when list
 			   (let*
 			       ;; utility function for maximum of list
-			       ((maximum (lambda (list) (my-seq-reduce (lambda (acc n) (max acc n)) list 0)))  
+			       ((maximum (lambda (list) (my-seq-reduce (lambda (acc n) (max acc n)) list 0)))
 				;; compute the maximum number of terms shadowed by this symbol
 				(max-shadows (lambda (symbol)
 					       (funcall
@@ -268,7 +268,7 @@ which currently consists of:\n
 						       (append alist (list (list 'is-unshadowed-p is-unshadowed-p)))))))
 			     ;; repeat for each instance in the list
 			     (mapcar add-is-unshadowed-p list))))))
-    (dolist (node (butlast path) (when (or terms types) (cons (funcall add-shadowed terms) (funcall add-shadowed types))))  
+    (dolist (node (butlast path) (when (or terms types) (cons (funcall add-shadowed terms) (funcall add-shadowed types))))
       (let ((binder (cdr (assoc 'binder (se-term-data node))))
 	    (bound-value (cdr (assoc 'bound-value (se-term-data node))))
 	    (children (se-node-children node)))
@@ -292,16 +292,16 @@ which currently consists of:\n
 		 (set-list
 		  ;; this takes the list to be modified and the type or kind containing the value data
 		  (lambda (q-lst value-source) ; quoted list -> list -> nil [mutates input 0]
-		    ;; we rename shadowed variables with a [+n] suffix or omit them		    
+		    ;; we rename shadowed variables with a [+n] suffix or omit them
 		    (let* ((shadows (funcall count-shadowed (eval q-lst) symbol count-shadowed)) ; number of symbols shadowed by this one
                            (fn-pos (cedille-mode-location-split location))
-			   (data (list 
+			   (data (list
 				  (cons 'value value-source) 		; the value displayed for the entry
 				  (cons 'bound-value bound-value)       ; the bound value of the variable (only used in let expressions)
 				  (cons 'keywords keywords-list) 	; keywords identifying attributes of the entry
 				  (cons 'location location)             ; the location of the definition; used in other files, but not this one
 				  (cons 'shadows shadows)))) 		; number of symbols shadowed by this one
-		      
+
 		      (set q-lst (cons (cons symbol data) (cedille-mode-context-shadow-tags (eval q-lst) symbol (car fn-pos) (cdr fn-pos))))))))
 	    (when (and symbol (not (equal symbol "_")) (or type kind)) 	; separate types and kinds
 	      (if type
@@ -366,7 +366,7 @@ which currently consists of:\n
 			  (symbol (car pair))
 			  (data (cdr pair))
 			  (is-shadowed-p (not (cadr (assoc 'is-unshadowed-p data))))
-			  
+
 			  ;; add dash for erased symbols
 			  (fsymbol (concat (if (cedille-mode-helpers-has-keyword pair "noterased") " " "-") symbol))
 			  ;; hide types and kinds in whiteout list
@@ -384,14 +384,14 @@ which currently consists of:\n
 				(if shadow-p
 				    list
 				  (funcall shadow-filter list))))
-	 
+
 	 (terms (funcall apply-shadow-filter-optionally (car context)))
 	 (types (funcall apply-shadow-filter-optionally (cdr context))))
     ;; return a pair where first element is list of formatted terms and second is list of formatted types
   (list
    (mapcar format terms)
    (mapcar format types))))
-    
+
 
 					; CONVENIENT FUNCTIONS
 

--- a/cedille-mode/cedille-mode-errors.el
+++ b/cedille-mode/cedille-mode-errors.el
@@ -1,7 +1,7 @@
 (make-variable-buffer-local
  (defvar cedille-mode-error-spans nil
    "List of all error spans."))
- 
+
 ;(make-variable-buffer-local
 ; (defvar cedille-mode-next-errors nil
 ;   "Next spans with an error value."))
@@ -26,7 +26,7 @@ of spans that have an error value."
       (when (cedille-span-has-error-data (se-span-data cur))
 	(push cur cedille-mode-error-spans))
       (cedille-find-error-spans (cdr spans)))))
-    
+
 (defun cedille-mode-set-error-spans()
   "After loading spans from the backend tool, this hook will look for error
 spans and set the variable `cedille-mode-error-spans'.  The input is ignored."
@@ -52,14 +52,14 @@ spans and set the variable `cedille-mode-error-spans'.  The input is ignored."
    (cedille-mode-update-buffers))
    ;;(display-buffer (cedille-mode-inspect)))
 
-(defun cedille-mode-select-first-error(selected-span)  
+(defun cedille-mode-select-first-error(selected-span)
   "Selects and highlights the first error in the selected span."
   (let ((first-error (car (delq nil (mapcar (lambda (x) (if (se-term-child-p x selected-span) x nil)) cedille-mode-error-spans)))))
     (if first-error
 	(cedille-mode-select-error first-error)
-        (message "No errors in selection")))) 
+        (message "No errors in selection"))))
 
-(defun cedille-mode-select-last-error(selected-span)  
+(defun cedille-mode-select-last-error(selected-span)
   "Selects and highlight the last error in the selected span."
   (let ((last-error (last (delq nil (mapcar (lambda (x) (if (se-term-child-p x selected-span) x nil)) cedille-mode-error-spans)))))
     (if last-error
@@ -176,7 +176,7 @@ spans and set the variable `cedille-mode-error-spans'.  The input is ignored."
        ((equal selected-span cedille-mode-cur-error) (cedille-mode-next-error 1))
         ; if the selected thing is another error, make it the current error
        ((member selected-span cedille-mode-error-spans) (cedille-mode-select-error selected-span))
-        ; otherwise select the first error in the selected span 
+        ; otherwise select the first error in the selected span
        (t (cedille-mode-select-first-error selected-span))))
 	(cedille-mode-select-next-error (- count 1))))
 

--- a/cedille-mode/cedille-mode-faces.el
+++ b/cedille-mode/cedille-mode-faces.el
@@ -17,7 +17,7 @@
 ;; default faces
 ;; ----------------------------------------------------------
 
-(defface cedille-error-face-df	       
+(defface cedille-error-face-df
    '((((background light))
       (:foreground unspecified :underline t :weight bold))
      (((background dark))
@@ -228,7 +228,7 @@
 	       ("Whitespace" . cedille-standard-face-df)
 	       ("Term-level definition (checking)" . cedille-defined-face-df)
 	       ("Type-level definition (checking)" . cedille-defined-face-df)
-	       ("Kind-level definition (checking)" . cedille-defined-face-df)))	       
+	       ("Kind-level definition (checking)" . cedille-defined-face-df)))
      ("language-level" . (("type" . cedille-type-face-df)
 			 ("kind" . cedille-kind-face-df)
 			 ("term" . cedille-standard-face-df)))
@@ -238,7 +238,7 @@
 
 
  (defvar cedille-mode-highlight-face-map-language-level
-   '( 
+   '(
      ("language-level" . (("type" . cedille-type-face-ll)
 			 ("kind" . cedille-kind-face-ll)
 			 ("term" . cedille-term-face-ll)))
@@ -282,8 +282,8 @@
 ;; -----------------------------------------------------------------
 ;; Hole Overlay
 ;; -----------------------------------------------------------------
-    
-   
+
+
 (defun cedille-mode-highlight-hole-overlay (spans)
   (when (car spans)
     (when (string= (se-span-name (car spans)) "Hole")

--- a/cedille-mode/cedille-mode-highlight.el
+++ b/cedille-mode/cedille-mode-highlight.el
@@ -25,7 +25,7 @@
 
 (make-variable-buffer-local
  (defvar cedille-mode-highlight-face-map nil
-   "Should be a mapping of qualities (strings) 
+   "Should be a mapping of qualities (strings)
    to a mapping of values (strings) with faces (variables)"))
 
 
@@ -42,14 +42,14 @@
 
 
 (defun cedille-mode-highlight-default ()
-  "Sets the cedille-mode-highlight-face-map variable to 
+  "Sets the cedille-mode-highlight-face-map variable to
    `cedille-mode-highlight-face-map-default' then highlights the file"
   (interactive)
   (set-cedille-mode-highlight-face-map cedille-mode-highlight-face-map-default)
   (cedille-mode-highlight))
 
 (defun cedille-mode-highlight-language-level ()
-  "Sets the cedille-mode-highlight-face-map variable to 
+  "Sets the cedille-mode-highlight-face-map variable to
    `cedille-mode-highlight-face-map-language-level' then highlights the file"
   (interactive)
   (set-cedille-mode-highlight-face-map cedille-mode-highlight-face-map-language-level)
@@ -105,7 +105,7 @@
   (let ((data (se-span-data span)))
     (cond
      ((string= quality "name") (se-span-name span))
-     ;; ((string= quality "error") (if (cdr (assoc 'error data)) "error" nil)) 
+     ;; ((string= quality "error") (if (cdr (assoc 'error data)) "error" nil))
      (t (cdr (assoc (intern quality) data))))))
 
 (defun cedille-mode-highlight-shadow-range (start end &optional object)

--- a/cedille-mode/cedille-mode-normalize.el
+++ b/cedille-mode/cedille-mode-normalize.el
@@ -42,7 +42,7 @@
      (lambda (input)
        (interactive "MErase: ")
        (cedille-mode-erase-send-prompt input)))))
-  
+
 
 ;;;;;;;;        Span Code        ;;;;;;;;
 

--- a/cedille-mode/cedille-mode-summary.el
+++ b/cedille-mode/cedille-mode-summary.el
@@ -4,7 +4,7 @@
 
 (defun cedille-mode-format-summary-text(text)
   "Remove newlines and instances of string ctor for display purposes"
-    (replace-regexp-in-string "\n" " " 
+    (replace-regexp-in-string "\n" " "
                     (replace-regexp-in-string "^ctor" " " text)))
 
 (defun cedille-mode-get-summary-from-span(table span)
@@ -14,14 +14,14 @@
       ;(message "summary: %s" summary)
       (when summary
 	(puthash (cedille-mode-format-summary-text summary)
-		 (cons nil (se-span-start span)) ; nil signifies location within current file 
+		 (cons nil (se-span-start span)) ; nil signifies location within current file
 		 table))))
 
 (defun cedille-mode-construct-summary-table()
   "Return a hash table with summary-text as key and (filename, start pos) as value"
   (let ((table (make-hash-table :test #'equal)))
-    (mapcar 
-     (lambda (span) 
+    (mapcar
+     (lambda (span)
        (cedille-mode-get-summary-from-span table span))
      se-mode-spans)
     table))
@@ -29,7 +29,7 @@
 (defun cedille-mode-get-hash-table-keys(table)
   "Return a list of keys(summary texts) from the summary table"
   (let ((keys ()))
-    (maphash 
+    (maphash
      (lambda(key val) (push key keys))
      table)
     (nreverse keys)))
@@ -90,7 +90,7 @@
 
 (defun cedille-mode-summary ()
   (let* ((summary-table (cedille-mode-construct-summary-table))
-	 (summary-string (cedille-mode-keylist-to-string 
+	 (summary-string (cedille-mode-keylist-to-string
 			  (cedille-mode-get-hash-table-keys summary-table))))
     (cedille-mode-summary-buffer-setup summary-string)))
 

--- a/se-mode/se-inf.el
+++ b/se-mode/se-inf.el
@@ -45,7 +45,7 @@ creating the parse tree from them."))
 
 (make-variable-buffer-local
  (defvar se-inf-get-message-from-filename (lambda (x) x)
-   "A function to call to compute the message to send to the backend 
+   "A function to call to compute the message to send to the backend
 a buffer is supposed to be parsed.  The function will be given the
 name of the file to parse, and should return the message that ought
 to be sent to the backend to request parsing of that file."))

--- a/se-mode/se-macros.el
+++ b/se-mode/se-macros.el
@@ -39,13 +39,13 @@ Example:
 ;	 (add-hook 'before-change-functions
 ;		   #'se-mode-push-parse-tree nil t)
 )
-       
+
        (defun ,(idf "%s-parse-file" prefix) ()
 	 "Only parses when navigation mode is active to prevent
 the navigation mode hook from calling `se-inf-parse-file' when
 deactivating. Most often one should use
 `se-inf-parse-file' instead."
-	 (when 
+	 (when
            (and se-navigation-mode
 	     (null se-mode-parse-tree))
 	   (se-inf-parse-file))))))

--- a/se-mode/se-mode.el
+++ b/se-mode/se-mode.el
@@ -144,26 +144,26 @@ selected, select it again."
       (message "No child span found"))))
 
 (defun se-mode-select-last-helper (prev)
-  "Helper function for selecting the last sibling span from a node 
+  "Helper function for selecting the last sibling span from a node
 of the tree."
   (let ((next (se-mode-next)))
     (if (null next) prev
       (se-mode-select next)
       (se-mode-select-last-helper next))))
-  
+
 (defun se-mode-select-last()
   "Selects the last sibling of the parent of the current node."
   (interactive)
   (se-mode-select-last-helper (se-mode-selected)))
 
 (defun se-mode-select-first-helper (next)
-  "Helper function for selecting the first sibling span from a node 
+  "Helper function for selecting the first sibling span from a node
 of the tree."
   (let ((prev (se-mode-previous)))
     (if (null prev) next
       (se-mode-select prev)
       (se-mode-select-first-helper prev))))
-  
+
 (defun se-mode-select-first()
   "Selects the first sibling of the parent of the current node."
   (interactive)

--- a/src/cedille-main.agda
+++ b/src/cedille-main.agda
@@ -22,7 +22,7 @@ putStrRunIf : 𝔹 → Run → IO ⊤
 putStrRunIf tt r = putStr (Run-to-string r) >> putStr "\n"
 putStrRunIf ff r = return triv
 
-processArgs : (showRun : 𝔹) → (showParsed : 𝔹) → 𝕃 string → IO ⊤ 
+processArgs : (showRun : 𝔹) → (showParsed : 𝔹) → 𝕃 string → IO ⊤
 processArgs showRun showParsed (input-filename :: []) = (readFiniteFile input-filename) >>= processText
   where processText : string → IO ⊤
         processText x with runRtn (string-to-𝕃char x)
@@ -31,12 +31,11 @@ processArgs showRun showParsed (input-filename :: []) = (readFiniteFile input-fi
         processText x | s | inj₂ r with putStrRunIf showRun r | rewriteRun r
         processText x | s | inj₂ r | sr | r' with putStrRunIf showParsed r'
         processText x | s | inj₂ r | sr | r' | sr' = sr >> sr' >> putStr (process r')
-                                     
-processArgs showRun showParsed ("--showRun" :: xs) = processArgs tt showParsed xs 
-processArgs showRun showParsed ("--showParsed" :: xs) = processArgs showRun tt xs 
+
+processArgs showRun showParsed ("--showRun" :: xs) = processArgs tt showParsed xs
+processArgs showRun showParsed ("--showParsed" :: xs) = processArgs showRun tt xs
 processArgs showRun showParsed (x :: xs) = putStr ("Unknown option " ^ x ^ "\n")
 processArgs showRun showParsed [] = putStr "Please run with the name of a file to process.\n"
 
 main : IO ⊤
 main = getArgs >>= processArgs ff ff
-

--- a/src/cedille-types.agda
+++ b/src/cedille-types.agda
@@ -114,38 +114,38 @@ data cases : Set
 data varargs : Set
 {-# COMPILE GHC varargs = type CedilleTypes.Varargs  #-}
 
-data arg where 
+data arg where
   TermArg : maybeErased → term → arg
   TypeArg : type → arg
 {-# COMPILE GHC arg = data CedilleTypes.Arg (CedilleTypes.TermArg | CedilleTypes.TypeArg) #-}
 
-data args where 
+data args where
   ArgsCons : arg → args → args
   ArgsNil : args
 {-# COMPILE GHC args = data CedilleTypes.Args (CedilleTypes.ArgsCons | CedilleTypes.ArgsNil) #-}
 
-data opacity where 
+data opacity where
   OpacOpaque : opacity
   OpacTrans : opacity
 {-# COMPILE GHC opacity = data CedilleTypes.Opacity (CedilleTypes.OpacOpaque | CedilleTypes.OpacTrans) #-}
 
-data cmd where 
+data cmd where
   DefKind : posinfo → kvar → params → kind → posinfo → cmd
   DefTermOrType : opacity → defTermOrType → posinfo → cmd
-  DefDatatype   : defDatatype   → posinfo → cmd    
+  DefDatatype   : defDatatype   → posinfo → cmd
   ImportCmd : imprt → cmd
 {-# COMPILE GHC cmd = data CedilleTypes.Cmd (CedilleTypes.DefKind | CedilleTypes.DefTermOrType | CedilleTypes.DefDatatype |CedilleTypes.ImportCmd) #-}
 
-data cmds where 
+data cmds where
   CmdsNext : cmd → cmds → cmds
   CmdsStart : cmds
 {-# COMPILE GHC cmds = data CedilleTypes.Cmds (CedilleTypes.CmdsNext | CedilleTypes.CmdsStart) #-}
 
-data decl where 
+data decl where
   Decl : posinfo → posinfo → maybeErased → bvar → tk → posinfo → decl
 {-# COMPILE GHC decl = data CedilleTypes.Decl (CedilleTypes.Decl) #-}
 
-data defDatatype where 
+data defDatatype where
   Datatype : posinfo → posinfo → var → params → kind → dataConsts → posinfo → defDatatype
 {-# COMPILE GHC defDatatype = data CedilleTypes.DefDatatype (CedilleTypes.Datatype) #-}
 
@@ -158,36 +158,36 @@ data dataConsts where
   DataCons : dataConst → dataConsts → dataConsts
 {-# COMPILE GHC dataConsts = data CedilleTypes.DataConsts (CedilleTypes.DataNull | CedilleTypes.DataCons) #-}
 
-data defTermOrType where 
+data defTermOrType where
   DefTerm : posinfo → var → optType → term → defTermOrType
   DefType : posinfo → var → kind → type → defTermOrType
 {-# COMPILE GHC defTermOrType = data CedilleTypes.DefTermOrType (CedilleTypes.DefTerm | CedilleTypes.DefType) #-}
 
-data imports where 
+data imports where
   ImportsNext : imprt → imports → imports
   ImportsStart : imports
 {-# COMPILE GHC imports = data CedilleTypes.Imports (CedilleTypes.ImportsNext | CedilleTypes.ImportsStart) #-}
 
-data imprt where 
+data imprt where
   Import : posinfo → optPublic → posinfo → fpth → optAs → args → posinfo → imprt
 {-# COMPILE GHC imprt = data CedilleTypes.Imprt (CedilleTypes.Import) #-}
 
-data kind where 
+data kind where
   KndArrow : kind → kind → kind
   KndParens : posinfo → kind → posinfo → kind
   KndPi : posinfo → posinfo → bvar → tk → kind → kind
   KndTpArrow : type → kind → kind
   KndVar : posinfo → qkvar → args → kind
   Star : posinfo → kind
-{-# COMPILE GHC kind = data CedilleTypes.Kind (CedilleTypes.KndArrow | CedilleTypes.KndParens | CedilleTypes.KndPi | CedilleTypes.KndTpArrow | CedilleTypes.KndVar | CedilleTypes.Star) #-}  
+{-# COMPILE GHC kind = data CedilleTypes.Kind (CedilleTypes.KndArrow | CedilleTypes.KndParens | CedilleTypes.KndPi | CedilleTypes.KndTpArrow | CedilleTypes.KndVar | CedilleTypes.Star) #-}
 
-data leftRight where 
+data leftRight where
   Both : leftRight
   Left : leftRight
   Right : leftRight
 {-# COMPILE GHC leftRight = data CedilleTypes.LeftRight (CedilleTypes.Both | CedilleTypes.Left | CedilleTypes.Right) #-}
 
-data liftingType where 
+data liftingType where
   LiftArrow : liftingType → liftingType → liftingType
   LiftParens : posinfo → liftingType → posinfo → liftingType
   LiftPi : posinfo → bvar → type → liftingType → liftingType
@@ -195,22 +195,22 @@ data liftingType where
   LiftTpArrow : type → liftingType → liftingType
 {-# COMPILE GHC liftingType = data CedilleTypes.LiftingType (CedilleTypes.LiftArrow | CedilleTypes.LiftParens | CedilleTypes.LiftPi | CedilleTypes.LiftStar | CedilleTypes.LiftTpArrow) #-}
 
-data lterms where 
+data lterms where
   LtermsCons : maybeErased → term → lterms → lterms
   LtermsNil : posinfo → lterms
 {-# COMPILE GHC lterms = data CedilleTypes.Lterms (CedilleTypes.LtermsCons | CedilleTypes.LtermsNil) #-}
 
-data optType where 
+data optType where
   SomeType : type → optType
   NoType : optType
 {-# COMPILE GHC optType = data CedilleTypes.OptType (CedilleTypes.SomeType | CedilleTypes.NoType) #-}
 
-data maybeErased where 
+data maybeErased where
   Erased : maybeErased
   NotErased : maybeErased
 {-# COMPILE GHC maybeErased = data CedilleTypes.MaybeErased (CedilleTypes.Erased | CedilleTypes.NotErased) #-}
 
-data maybeMinus where 
+data maybeMinus where
   EpsHanf : maybeMinus
   EpsHnf : maybeMinus
 {-# COMPILE GHC maybeMinus = data CedilleTypes.MaybeMinus (CedilleTypes.EpsHanf | CedilleTypes.EpsHnf) #-}
@@ -220,7 +220,7 @@ data nums where
   NumsNext : num → nums → nums
 {-# COMPILE GHC nums = data CedilleTypes.Nums (CedilleTypes.NumsStart | CedilleTypes.NumsNext) #-}
 
-data optAs where 
+data optAs where
   NoOptAs : optAs
   SomeOptAs : posinfo → var → optAs
 {-# COMPILE GHC optAs = data CedilleTypes.OptAs (CedilleTypes.NoOptAs | CedilleTypes.SomeOptAs) #-}
@@ -230,41 +230,41 @@ data optPublic where
   IsPublic : optPublic
 {-# COMPILE GHC optPublic = data CedilleTypes.OptPublic (CedilleTypes.NotPublic | CedilleTypes.IsPublic) #-}
 
-data optClass where 
+data optClass where
   NoClass : optClass
   SomeClass : tk → optClass
 {-# COMPILE GHC optClass = data CedilleTypes.OptClass (CedilleTypes.NoClass | CedilleTypes.SomeClass) #-}
 
-data optGuide where 
+data optGuide where
   NoGuide : optGuide
   Guide : posinfo → var → type → optGuide
 {-# COMPILE GHC optGuide = data CedilleTypes.OptGuide (CedilleTypes.NoGuide | CedilleTypes.Guide) #-}
 
-data optPlus where 
+data optPlus where
   RhoPlain : optPlus
   RhoPlus : optPlus
 {-# COMPILE GHC optPlus = data CedilleTypes.OptPlus (CedilleTypes.RhoPlain | CedilleTypes.RhoPlus) #-}
 
-data optNums where 
+data optNums where
   NoNums : optNums
   SomeNums : nums → optNums
 {-# COMPILE GHC optNums = data CedilleTypes.OptNums (CedilleTypes.NoNums | CedilleTypes.SomeNums) #-}
 
-data optTerm where 
+data optTerm where
   NoTerm : optTerm
   SomeTerm : term → posinfo → optTerm
-{-# COMPILE GHC optTerm = data CedilleTypes.OptTerm (CedilleTypes.NoTerm | CedilleTypes.SomeTerm) #-}  
+{-# COMPILE GHC optTerm = data CedilleTypes.OptTerm (CedilleTypes.NoTerm | CedilleTypes.SomeTerm) #-}
 
-data params where 
+data params where
   ParamsCons : decl → params → params
   ParamsNil : params
 {-# COMPILE GHC params = data CedilleTypes.Params (CedilleTypes.ParamsCons | CedilleTypes.ParamsNil) #-}
 
-data start where 
+data start where
   File : posinfo → imports → posinfo → posinfo → qvar → params → cmds → posinfo → start
-{-# COMPILE GHC start = data CedilleTypes.Start (CedilleTypes.File) #-}  
+{-# COMPILE GHC start = data CedilleTypes.Start (CedilleTypes.File) #-}
 
-data term where 
+data term where
   App : term → maybeErased → term → term
   AppTp : term → type → term
   Beta : posinfo → optTerm → optTerm → term
@@ -278,7 +278,7 @@ data term where
   Let : posinfo → defTermOrType → term → term
   Open : posinfo → var → term → term
   Parens : posinfo → term → posinfo → term
-  Phi : posinfo → term → term → term → posinfo → term  
+  Phi : posinfo → term → term → term → posinfo → term
   Rho : posinfo → optPlus → optNums → term → optGuide → term → term
   Sigma : posinfo → term → term
   Theta : posinfo → theta → term → lterms → term
@@ -294,23 +294,23 @@ data cases where
 
 data varargs where
   NoVarargs : varargs
-  NormalVararg : bvar → varargs → varargs 
-  ErasedVararg : bvar → varargs → varargs 
-  TypeVararg   : bvar → varargs → varargs 
-{-# COMPILE GHC varargs = data CedilleTypes.Varargs (CedilleTypes.NoVarargs | CedilleTypes.NormalVararg | CedilleTypes.ErasedVararg | CedilleTypes.TypeVararg ) #-}  
-  
-data theta where 
+  NormalVararg : bvar → varargs → varargs
+  ErasedVararg : bvar → varargs → varargs
+  TypeVararg   : bvar → varargs → varargs
+{-# COMPILE GHC varargs = data CedilleTypes.Varargs (CedilleTypes.NoVarargs | CedilleTypes.NormalVararg | CedilleTypes.ErasedVararg | CedilleTypes.TypeVararg ) #-}
+
+data theta where
   Abstract : theta
   AbstractEq : theta
   AbstractVars : vars → theta
-{-# COMPILE GHC theta = data CedilleTypes.Theta (CedilleTypes.Abstract | CedilleTypes.AbstractEq | CedilleTypes.AbstractVars) #-}      
+{-# COMPILE GHC theta = data CedilleTypes.Theta (CedilleTypes.Abstract | CedilleTypes.AbstractEq | CedilleTypes.AbstractVars) #-}
 
-data tk where 
+data tk where
   Tkk : kind → tk
   Tkt : type → tk
-{-# COMPILE GHC tk = data CedilleTypes.Tk (CedilleTypes.Tkk | CedilleTypes.Tkt) #-}        
+{-# COMPILE GHC tk = data CedilleTypes.Tk (CedilleTypes.Tkk | CedilleTypes.Tkt) #-}
 
-data type where 
+data type where
   Abs : posinfo → maybeErased → posinfo → bvar → tk → type → type
   Iota : posinfo → posinfo → bvar → type → type → type
   Lft : posinfo → posinfo → var → term → liftingType → type
@@ -326,7 +326,7 @@ data type where
   TpVar : posinfo → qvar → type
 {-# COMPILE GHC type = data CedilleTypes.Type (CedilleTypes.Abs | CedilleTypes.Iota | CedilleTypes.Lft | CedilleTypes.NoSpans | CedilleTypes.TpLet | CedilleTypes.TpApp | CedilleTypes.TpAppt | CedilleTypes.TpArrow | CedilleTypes.TpEq | CedilleTypes.TpHole | CedilleTypes.TpLambda | CedilleTypes.TpParens | CedilleTypes.TpVar) #-}
 
-data vars where 
+data vars where
   VarsNext : var → vars → vars
   VarsStart : var → vars
 {-# COMPILE GHC vars = data CedilleTypes.Vars (CedilleTypes.VarsNext | CedilleTypes.VarsStart) #-}

--- a/src/classify.agda
+++ b/src/classify.agda
@@ -23,7 +23,7 @@ check-ret : ∀{A : Set} → maybe A → Set
 check-ret{A} nothing = maybe A
 check-ret (just _) = ⊤
 
-infixl 2 _≫=spanr_ 
+infixl 2 _≫=spanr_
 _≫=spanr_ : ∀{A : Set}{m : maybe A} → spanM (maybe A) → (A → spanM (check-ret m)) → spanM (check-ret m)
 _≫=spanr_{m = nothing} = _≫=spanm_
 _≫=spanr_{m = just _} = _≫=spanj_
@@ -70,15 +70,15 @@ check-term-update-eq Γ Right m pi t1 t2 pi' = TpEq pi t1 (hnf-from Γ tt m t2) 
 check-term-update-eq Γ Both m pi t1 t2 pi' = TpEq pi (hnf-from Γ tt m t1) (hnf-from Γ tt m t2) pi'
 
 add-tk' : erased? → posinfo → var → tk → spanM restore-def
-add-tk' e pi x atk = 
-   helper atk ≫=span λ mi → 
+add-tk' e pi x atk =
+   helper atk ≫=span λ mi →
     (if ~ (x =string ignored-var) then
-       (get-ctxt λ Γ → 
+       (get-ctxt λ Γ →
           spanM-add (var-span e Γ pi x checking atk nothing))
     else spanMok) ≫span
    spanMr mi
   where helper : tk → spanM restore-def
-        helper (Tkk k) = spanM-push-type-decl pi x k 
+        helper (Tkk k) = spanM-push-type-decl pi x k
         helper (Tkt t) = spanM-push-term-decl pi x t
 
 add-tk : posinfo → var → tk → spanM restore-def
@@ -100,11 +100,11 @@ lambda-bound-class-if NoClass atk = atk
 lambda-bound-class-if (SomeClass atk') atk = atk'
 
 {- for check-term and check-type, if the optional classifier is given, we will check against it.
-   Otherwise, we will try to synthesize a type.  
+   Otherwise, we will try to synthesize a type.
    check-type should return kinds in hnf using check-type-return.
    Use add-tk above to add declarations to the ctxt, since these should be normalized
    and with self-types instantiated.
-   
+
    The term/type/kind being checked is never qualified, but the type/kind it is being
    checked against should always be qualified. So if a term/type is ever being checked
    against something that was in a term/type the user wrote (phi, for example, needs to
@@ -158,10 +158,10 @@ valid-elim-kind t (KndPi _ pix x (Tkt t1)  k1) (KndPi _ _ y (Tkt  t2) k2)  pi pi
 valid-elim-kind t (KndPi _ pix x (Tkk k1') k1) (KndPi _ _ y (Tkk  k2') k2) pi pi' =
   get-ctxt (λ Γ →
     if (conv-kind Γ k1' k2') then
-      set-ctxt (ctxt-type-decl pix x k1' Γ) ≫span 
+      set-ctxt (ctxt-type-decl pix x k1' Γ) ≫span
       valid-elim-kind (TpApp  t (TpVar pix x)) k1 k2 pi pi'
     else
-      spanM-add (mk-span "Motive error" pi pi' [] (just "Not a valid motive 5")))   
+      spanM-add (mk-span "Motive error" pi pi' [] (just "Not a valid motive 5")))
 valid-elim-kind t (KndTpArrow t1 k1)           (KndTpArrow t2 k2)          pi pi' =
   get-ctxt (λ Γ →
     if (conv-type Γ t1  t2) then
@@ -174,17 +174,17 @@ valid-elim-kind _ _ _ pi pi'  =
 {- Cedilleum specification, section 4.4 -}
 branch-type : ctxt → term → type → type → type
 --  Π x : Tk, ∀ x : T, ∀ x : k cases
-branch-type Γ t (Abs pi e pi' x tk ty) m = Abs pi e pi' x tk (branch-type Γ t ty m) 
+branch-type Γ t (Abs pi e pi' x tk ty) m = Abs pi e pi' x tk (branch-type Γ t ty m)
 branch-type Γ t _                      m = TpAppt m t -- TODO: missing indices s ! is ctxt needed ?
 
 -- converts mu cases (Example: from "vcons -n -m x xs -eq → ff" to "Λ n. Λ m. λ x. λ xs. Λ eq. ff")
 abstract-varargs : varargs → term → spanM (maybe term)
 abstract-varargs NoVarargs           t = spanMr (just t)
 abstract-varargs (NormalVararg x vs) t =
-  (abstract-varargs vs t) on-fail (spanMr nothing) ≫=spanm' (λ a → 
+  (abstract-varargs vs t) on-fail (spanMr nothing) ≫=spanm' (λ a →
     spanMr (just (Lam posinfo-gen NotErased posinfo-gen x NoClass  a)))
 abstract-varargs (ErasedVararg x vs) t =
-  (abstract-varargs vs t) on-fail (spanMr nothing) ≫=spanm' (λ a → 
+  (abstract-varargs vs t) on-fail (spanMr nothing) ≫=spanm' (λ a →
     spanMr (just (Lam posinfo-gen Erased    posinfo-gen x NoClass  a)))
 abstract-varargs (TypeVararg   x vs) t =
   (abstract-varargs vs t) on-fail (spanMr nothing) ≫=spanm' (λ a →
@@ -204,7 +204,7 @@ check-cases _ _ _ _ pic pic' = spanM-add (mk-span "Mu Cases error" pic pic' [] (
 {- Cedilleum specification, section 4.5 -}
 well-formed-patterns : defDatatype → term → type → cases → posinfo → posinfo → spanM ⊤
 well-formed-patterns dd@(Datatype pi pix x ps k cons pf) t P cases pic pic' =
-  (check-type P nothing) on-fail (spanM-add (mk-span "Wrong motive" (type-start-pos P) (type-end-pos P) [] (just "Motive does not typecheck"))) ≫=spanm' (λ kmtv → 
+  (check-type P nothing) on-fail (spanM-add (mk-span "Wrong motive" (type-start-pos P) (type-end-pos P) [] (just "Motive does not typecheck"))) ≫=spanm' (λ kmtv →
     get-ctxt (λ Γ → valid-elim-kind (lam-expand-type ps (qualif-type Γ (TpVar pix x))) k kmtv (type-start-pos P) (type-end-pos P) ≫span
       check-cases cons cases ps P pic pic'))
 
@@ -237,14 +237,14 @@ check-termi (Var pi x) mtp =
   get-ctxt (cont mtp)
   where cont : (mtp : maybe type) → ctxt → spanM (check-ret mtp)
         cont mtp Γ with ctxt-lookup-term-var Γ x
-        cont mtp Γ | nothing = 
+        cont mtp Γ | nothing =
          spanM-add (Var-span Γ pi x (maybe-to-checking mtp)
                       (expected-type-if Γ mtp ++ [ missing-type ]) (just "Missing a type for a term variable.")) ≫span
          return-when mtp mtp
-        cont nothing Γ | just tp = 
+        cont nothing Γ | just tp =
           spanM-add (Var-span Γ pi x synthesizing [ type-data Γ tp ] nothing)
           ≫span spanMr (just tp)
-        cont (just tp) Γ | just tp' = 
+        cont (just tp) Γ | just tp' =
           spanM-add (uncurry (Var-span Γ pi x checking) (check-for-type-mismatch Γ "synthesized" tp tp'))
 
 check-termi t'@(AppTp t tp') mtp =
@@ -291,8 +291,8 @@ check-termi (Let pi d t) mtp =
         -- be substituted into a checking position, or vice-versa with a checking term let.
 
         finish : (var × restore-def) → spanM (check-ret mtp)
-        finish (x , m) = 
-         get-ctxt λ Γ → 
+        finish (x , m) =
+         get-ctxt λ Γ →
          spanM-add (Let-span Γ (maybe-to-checking mtp) pi d t [] nothing) ≫span
          check-term t mtp ≫=span λ r →
          spanM-restore-info x m ≫span
@@ -329,18 +329,18 @@ check-termi (Open pi x t) mtp = get-ctxt λ Γ →
 check-termi (Lam pi l pi' x (SomeClass atk) t) nothing =
   spanM-add (punctuation-span "Lambda" pi (posinfo-plus pi 1)) ≫span
   check-tk atk ≫span
-    add-tk pi' x atk ≫=span λ mi → 
-    check-term t nothing ≫=span λ mtp → 
+    add-tk pi' x atk ≫=span λ mi →
+    check-term t nothing ≫=span λ mtp →
     spanM-restore-info x mi ≫span -- now restore the context
     cont mtp
 
   where cont : maybe type → spanM (maybe type)
         cont nothing =
-          get-ctxt λ Γ → 
-          spanM-add (Lam-span Γ synthesizing pi l x (SomeClass atk) t [] nothing) ≫span 
+          get-ctxt λ Γ →
+          spanM-add (Lam-span Γ synthesizing pi l x (SomeClass atk) t [] nothing) ≫span
           spanMr nothing
         cont (just tp) =
-          get-ctxt λ Γ → 
+          get-ctxt λ Γ →
           let atk' = qualif-tk Γ atk in
           -- This should indeed "unqualify" occurrences of x in tp for rettp
           let rettp = abs-tk l x atk' (rename-var Γ (pi' % x) x tp) in
@@ -350,7 +350,7 @@ check-termi (Lam pi l pi' x (SomeClass atk) t) nothing =
           check-termi-return-hnf Γ (Lam pi l pi' x (SomeClass atk) t) rettp
 
 check-termi (Lam pi l _ x NoClass t) nothing =
-  get-ctxt λ Γ → 
+  get-ctxt λ Γ →
   spanM-add (punctuation-span "Lambda" pi (posinfo-plus pi 1)) ≫span
   spanM-add (Lam-span Γ synthesizing pi l x NoClass t []
               (just ("We are not checking this abstraction against a type, so a classifier must be"
@@ -365,12 +365,12 @@ check-termi (Lam pi l pi' x oc t) (just tp) =
       spanM-add (punctuation-span "Lambda" pi (posinfo-plus pi 1)) ≫span
       get-ctxt λ Γ →
       spanM-add (uncurry (this-span Γ atk oc) (check-erasures Γ l b)) ≫span
-      add-tk' (me-erased l) pi' x (lambda-bound-class-if oc atk) ≫=span λ mi → 
+      add-tk' (me-erased l) pi' x (lambda-bound-class-if oc atk) ≫=span λ mi →
       get-ctxt λ Γ' → check-term t (just (rename-var Γ x' (qualif-var Γ' x) tp')) ≫span
       spanM-restore-info x mi where
         this-span : ctxt → tk → optClass → 𝕃 tagged-val → err-m → span
         this-span Γ _ NoClass tvs = Lam-span Γ checking pi l x oc t tvs
-        this-span Γ atk (SomeClass atk') tvs err = 
+        this-span Γ atk (SomeClass atk') tvs err =
           if conv-tk Γ (qualif-tk Γ atk') atk then
             Lam-span Γ checking pi l x oc t tvs err
           else
@@ -380,7 +380,7 @@ check-termi (Lam pi l pi' x oc t) (just tp) =
         check-oc NoClass = spanMok
         check-oc (SomeClass atk) = check-tk atk
         check-erasures : ctxt → maybeErased → maybeErased → 𝕃 tagged-val × err-m
-        check-erasures Γ Erased All = 
+        check-erasures Γ Erased All =
           if is-free-in skip-erased x t
             then type-data Γ tp :: [ erasure Γ t ] , just "The Λ-bound variable occurs free in the erasure of the body."
             else [ type-data Γ tp ] , nothing
@@ -401,7 +401,7 @@ check-termi (Beta pi ot ot') (just tp) =
   get-ctxt λ Γ →
   spanM-add (uncurry (Beta-span pi (optTerm-end-pos-beta pi ot ot') checking)
     (case hnf Γ unfold-head tp tt of λ where
-      (TpEq pi' t1 t2 pi'') → 
+      (TpEq pi' t1 t2 pi'') →
         if conv-term Γ t1 t2
           then [ type-data Γ (TpEq pi' t1 t2 pi'') ] , (optTerm-conv Γ t1 ot)
           else [ expected-type Γ (TpEq pi' t1 t2 pi'') ] , (just "The two terms in the equation are not β-equal")
@@ -419,33 +419,33 @@ check-termi (Beta pi (SomeTerm t pi') ot) nothing =
   spanM-add (Beta-span pi (optTerm-end-pos-beta pi (SomeTerm t pi') ot) synthesizing [ type-data Γ tp ] nothing) ≫span
   spanMr (just tp)
 
-check-termi (Beta pi NoTerm ot') nothing = 
+check-termi (Beta pi NoTerm ot') nothing =
   untyped-optTerm-spans ot' ≫span
   spanM-add (Beta-span pi (optTerm-end-pos-beta pi NoTerm ot') synthesizing [] (just "An expected type is required in order to type a use of plain β.")) ≫span
   spanMr nothing
 
-check-termi (Epsilon pi lr m t) (just tp) = -- (TpEq pi' t1 t2 pi'')) = 
-  get-ctxt λ Γ → 
+check-termi (Epsilon pi lr m t) (just tp) = -- (TpEq pi' t1 t2 pi'')) =
+  get-ctxt λ Γ →
   case hnf Γ unfold-head tp tt of λ where
     (TpEq pi' t1 t2 pi'') →
       spanM-add (Epsilon-span pi lr m t checking [ type-data Γ (TpEq pi' t1 t2 pi'') ] nothing) ≫span
       check-term t (just (check-term-update-eq Γ lr m pi' t1 t2 pi''))
     tp → spanM-add (Epsilon-span pi lr m t checking [ expected-type Γ tp ] (just "The expected type is not an equation, when checking an ε-term."))
 
-check-termi (Epsilon pi lr m t) nothing = 
+check-termi (Epsilon pi lr m t) nothing =
   check-term t nothing ≫=span λ mtp → get-ctxt λ Γ → cont (maybe-hnf Γ mtp)
   where cont : maybe type → spanM (maybe type)
-        cont nothing = 
+        cont nothing =
           spanM-add (Epsilon-span pi lr m t synthesizing []
             (just "There is no expected type, and we could not synthesize a type from the body of the ε-term.")) ≫span
           spanMr nothing
         cont (just (TpEq pi' t1 t2 pi'')) =
-          get-ctxt λ Γ → 
+          get-ctxt λ Γ →
           let r = check-term-update-eq Γ lr m pi' t1 t2 pi'' in
           spanM-add (Epsilon-span pi lr m t synthesizing [ type-data Γ r ] nothing) ≫span
           spanMr (just r)
-        cont (just tp) = 
-          get-ctxt λ Γ → 
+        cont (just tp) =
+          get-ctxt λ Γ →
           spanM-add (Epsilon-span pi lr m t synthesizing [ to-string-tag "the synthesized type" Γ tp ]
             (just "There is no expected type, and the type we synthesized for the body of the ε-term is not an equation.")) ≫span
           spanMr nothing
@@ -553,7 +553,7 @@ check-termi (Rho pi op on t NoGuide t') (just tp) =
   cont (maybe-hnf Γ mtp) (hnf Γ unfold-head-no-lift tp tt)
   where cont : maybe type → type → spanM ⊤
         cont nothing tp = get-ctxt λ Γ → spanM-add (Rho-span pi t t' checking op (inj₁ 0) [ expected-type Γ tp ] nothing) ≫span check-term t' (just tp)
-        cont (just (TpEq pi' t1 t2 pi'')) tp = 
+        cont (just (TpEq pi' t1 t2 pi'')) tp =
            get-ctxt λ Γ →
              let ns-err = optNums-to-stringset on
                  x = fresh-var "x" (ctxt-binds-var Γ) empty-renamectxt
@@ -569,13 +569,13 @@ check-termi (Rho pi op on t NoGuide t') (just tp) =
                                        :: [ expected-type Γ tp ])
                                      (just "We could not synthesize an equation from the first subterm in a ρ-term."))
 
-check-termi (Rho pi op on t NoGuide t') nothing = 
-  check-term t nothing ≫=span λ mtp → 
+check-termi (Rho pi op on t NoGuide t') nothing =
+  check-term t nothing ≫=span λ mtp →
   check-term t' nothing ≫=span λ mtp' → get-ctxt λ Γ → cont (maybe-hnf Γ mtp)
     (maybe-map (λ mtp' → hnf Γ unfold-head-no-lift mtp' tt) mtp')
   where cont : maybe type → maybe type → spanM (maybe type)
-        cont (just (TpEq pi' t1 t2 pi'')) (just tp) = 
-          get-ctxt λ Γ → 
+        cont (just (TpEq pi' t1 t2 pi'')) (just tp) =
+          get-ctxt λ Γ →
             let ns-err = optNums-to-stringset on
                 x = fresh-var "x" (ctxt-binds-var Γ) empty-renamectxt
                 qt = qualif-term Γ t
@@ -597,14 +597,14 @@ check-termi (Chi pi (SomeType tp) t) mtp =
   where cont : type → (m : maybe type) → spanM (check-ret m)
         cont tp' nothing = get-ctxt λ Γ → spanM-add (Chi-span Γ pi (SomeType tp) t synthesizing [] nothing) ≫span spanMr (just tp')
         cont tp' (just tp'') =
-          get-ctxt λ Γ → 
+          get-ctxt λ Γ →
           spanM-add (uncurry (Chi-span Γ pi (SomeType tp') t checking) (check-for-type-mismatch Γ "asserted" tp'' tp'))
-check-termi (Chi pi NoType t) (just tp) = 
-  check-term t nothing ≫=span cont 
+check-termi (Chi pi NoType t) (just tp) =
+  check-term t nothing ≫=span cont
   where cont : (m : maybe type) → spanM ⊤
         cont nothing = get-ctxt (λ Γ → spanM-add (Chi-span Γ pi NoType t checking [] nothing) ≫span spanMok)
         cont (just tp') =
-          get-ctxt λ Γ → 
+          get-ctxt λ Γ →
           spanM-add (uncurry (Chi-span Γ pi NoType t checking) (check-for-type-mismatch Γ "synthesized" tp tp'))
 check-termi (Chi pi NoType t) nothing =
  get-ctxt λ Γ → spanM-add (Chi-span Γ pi NoType t synthesizing [] nothing) ≫span check-term t nothing
@@ -615,7 +615,7 @@ check-termi (Delta pi mT t) mtp =
   spanM-add (Delta-span Γ pi mT t (maybe-to-checking mtp) [] (maybe-hnf Γ T ≫=maybe check-contra Γ)) ≫span
   (case mT of λ where
     NoType → spanMr compileFailType
-    (SomeType T) → check-type T (just (Star posinfo-gen)) ≫span spanMr T) ≫=span λ T → 
+    (SomeType T) → check-type T (just (Star posinfo-gen)) ≫span spanMr T) ≫=span λ T →
   return-when mtp (just (qualif-type Γ T))
   where check-contra : ctxt → type → err-m
         check-contra Γ (TpEq _ t1 t2 _) =
@@ -634,15 +634,15 @@ check-termi (Theta pi AbstractEq t ls) (just tp) =
   -- discard spans from checking t, because we will check it again below
   check-term t nothing ≫=spand λ mtp → get-ctxt λ Γ → cont (maybe-hnf Γ mtp) (hnf Γ unfold-head tp tt)
   where cont : maybe type → type → spanM ⊤
-        cont nothing tp = check-term t nothing ≫=span λ m → 
+        cont nothing tp = check-term t nothing ≫=span λ m →
                        get-ctxt λ Γ →
                           spanM-add (Theta-span Γ pi AbstractEq t ls checking [ expected-type Γ tp ] (just "We could not compute a motive from the given term"))
                                       -- (expected-type Γ tp :: [ motive-label , [[ "We could not compute a motive from the given term" ]] , [] ]))))
         cont (just htp) tp =
-           get-ctxt λ Γ → 
+           get-ctxt λ Γ →
              let x = (fresh-var "x" (ctxt-binds-var Γ) empty-renamectxt) in
              let motive = mtplam x (Tkt htp) (TpArrow (TpEq posinfo-gen t (mvar x) posinfo-gen) Erased tp) in
-               spanM-add (Theta-span Γ pi AbstractEq t ls checking (expected-type Γ tp :: [ the-motive Γ motive ]) nothing) ≫span 
+               spanM-add (Theta-span Γ pi AbstractEq t ls checking (expected-type Γ tp :: [ the-motive Γ motive ]) nothing) ≫span
                check-term (lterms-to-term AbstractEq (AppTp t (NoSpans motive (posinfo-plus (term-end-pos t) 1))) ls)
                  (just tp)
 
@@ -650,17 +650,17 @@ check-termi (Theta pi Abstract t ls) (just tp) =
   -- discard spans from checking the head, because we will check it again below
   check-term t nothing ≫=spand λ mtp → get-ctxt λ Γ → cont t (maybe-hnf Γ mtp) (hnf Γ unfold-head tp tt)
   where cont : term → maybe type → type → spanM ⊤
-        cont _ nothing tp = check-term t nothing ≫=span λ m → 
+        cont _ nothing tp = check-term t nothing ≫=span λ m →
                          get-ctxt λ Γ →
                            spanM-add (Theta-span Γ pi Abstract t ls checking [ expected-type Γ tp ] (just "We could not compute a motive from the given term"))
                                       -- (expected-type Γ tp :: [ motive-label , [[ "We could not compute a motive from the given term" ]] , [] ]))))
-        cont t (just htp) tp = 
+        cont t (just htp) tp =
           get-ctxt λ Γ →
           let x = compute-var (hnf Γ unfold-head (qualif-term Γ t) tt)
               x' = maybe-else (unqual-local x) id (var-suffix x) in
           let motive = mtplam x' (Tkt htp) (rename-var Γ x x' tp) in
-            spanM-add (Theta-span Γ pi Abstract t ls checking (expected-type Γ tp :: [ the-motive Γ motive ]) nothing) ≫span 
-            check-term (lterms-to-term Abstract (AppTp t (NoSpans motive (term-end-pos t))) ls) 
+            spanM-add (Theta-span Γ pi Abstract t ls checking (expected-type Γ tp :: [ the-motive Γ motive ]) nothing) ≫span
+            check-term (lterms-to-term Abstract (AppTp t (NoSpans motive (term-end-pos t))) ls)
                (just tp)
           where compute-var : term → var
                 compute-var (Var pi' x) = x
@@ -674,14 +674,14 @@ check-termi (Theta pi (AbstractVars vs) t ls) (just tp) =
         wrap-vars Γ (VarsStart v) tp = wrap-var Γ v tp
         wrap-vars Γ (VarsNext v vs) tp = wrap-vars Γ vs tp ≫=maybe wrap-var Γ v
         cont : maybe type → type → spanM ⊤
-        cont nothing tp = check-term t nothing ≫=span λ m → 
+        cont nothing tp = check-term t nothing ≫=span λ m →
                        get-ctxt λ Γ →
                        spanM-add (Theta-span Γ pi (AbstractVars vs) t ls checking
                                     [ expected-type Γ tp ] (just ("We could not compute a motive from the given term"
                                                                      ^ " because one of the abstracted vars is not in scope.")))
         cont (just motive) tp =
            get-ctxt λ Γ →
-            spanM-add (Theta-span Γ pi (AbstractVars vs) t ls checking (expected-type Γ tp :: [ the-motive Γ motive ]) nothing) ≫span 
+            spanM-add (Theta-span Γ pi (AbstractVars vs) t ls checking (expected-type Γ tp :: [ the-motive Γ motive ]) nothing) ≫span
             check-term (lterms-to-term Abstract (AppTp t (NoSpans motive (posinfo-plus (term-end-pos t) 1))) ls)
                (just tp)
         {-rep-var : ctxt → var → trie term → trie term
@@ -789,7 +789,7 @@ check-termi mu@(Mu' pi t (SomeType P) pi' cs pi'')   (just tp) =
     helper _          Γ          = spanMok
 check-termi (Mu' pi t NoType       _ cs pi')   (just tp) = spanMok
 check-termi (Mu' pi t NoType       _ cs pi')   nothing   = spanMr nothing
-check-termi (Mu  pi x t (SomeType m) _ cs pi') (just tp) = spanMok 
+check-termi (Mu  pi x t (SomeType m) _ cs pi') (just tp) = spanMok
 check-termi (Mu  pi x t (SomeType m) _ cs pi') nothing   = spanMr nothing
 check-termi (Mu  pi x t NoType _ cs pi')       nothing   = spanMr nothing
 check-termi (Mu  pi x t NoType _ cs pi')       (just tp) = spanMok
@@ -1313,7 +1313,7 @@ match-types Xs Ls unf tpₓ'@(Abs piₓ bₓ piₓ' xₓ tkₓ tpₓ) tp'@(Abs p
   if ~ eq-maybeErased bₓ b
     then (match-types-error m-err.e-match-failure) else
   ( match-tks Xs Ls (match-unfolding-next unf) tkₓ tk
-  ≫=spans' λ Xs' → with-ctxt (Γ→Γ' Γ) 
+  ≫=spans' λ Xs' → with-ctxt (Γ→Γ' Γ)
     (match-types Xs' Ls' (match-unfolding-next unf) tpₓ tp))
   where
   Γ→Γ' : ctxt → ctxt
@@ -1587,7 +1587,7 @@ match-prototype Xs uf tp@(Lft _ _ _ _ _) pt@(proto-arrow _ _) =
 
 --ACG WIP
 --check-typei (TpHole pi) k = spanM-add
-check-typei (TpHole pi) k = 
+check-typei (TpHole pi) k =
   get-ctxt (λ Γ → spanM-add (tp-hole-span Γ pi k []) ≫span return-when k k)
 
 
@@ -1597,33 +1597,33 @@ check-typei (TpParens pi t pi') k =
 check-typei (NoSpans t _) k = check-type t k ≫=spand spanMr
 check-typei (TpVar pi x) mk =
   get-ctxt (cont mk)
-  where cont : (mk : maybe kind) → ctxt → spanM (check-ret mk) 
+  where cont : (mk : maybe kind) → ctxt → spanM (check-ret mk)
         cont mk Γ with ctxt-lookup-type-var Γ x
-        cont mk Γ | nothing = 
+        cont mk Γ | nothing =
           spanM-add (TpVar-span Γ pi x (maybe-to-checking mk)
                        (expected-kind-if Γ mk ++ [ missing-kind ])
                        (just "Missing a kind for a type variable.")) ≫span
           return-when mk mk
-        cont nothing Γ | (just k) = 
+        cont nothing Γ | (just k) =
           spanM-add (TpVar-span Γ pi x synthesizing [ kind-data Γ k ] nothing) ≫span
           check-type-return Γ k
-        cont (just k) Γ | just k' = 
+        cont (just k) Γ | just k' =
          spanM-add (TpVar-span Γ pi x checking
            (expected-kind Γ k :: [ kind-data Γ k' ])
            (if conv-kind Γ k k' then nothing else just "The computed kind does not match the expected kind."))
-check-typei (TpLambda pi pi' x atk body) (just k) with to-absk k 
+check-typei (TpLambda pi pi' x atk body) (just k) with to-absk k
 check-typei (TpLambda pi pi' x atk body) (just k) | just (mk-absk x' atk' _ k') =
    check-tk atk ≫span
    spanM-add (punctuation-span "Lambda (type)" pi (posinfo-plus pi 1)) ≫span
-   get-ctxt λ Γ → 
+   get-ctxt λ Γ →
    spanM-add (if conv-tk Γ (qualif-tk Γ atk) atk' then
                 TpLambda-span pi x atk body checking [ kind-data Γ k ] nothing
               else
                 uncurry (λ tvs err → TpLambda-span pi x atk body checking tvs (just err)) (lambda-bound-var-conv-error Γ x atk' atk [ kind-data Γ k ])) ≫span
-   add-tk pi' x atk ≫=span λ mi → 
+   add-tk pi' x atk ≫=span λ mi →
    get-ctxt λ Γ' → check-type body (just (rename-var Γ x' (qualif-var Γ' x) k')) ≫span
    spanM-restore-info x mi
-check-typei (TpLambda pi pi' x atk body) (just k) | nothing = 
+check-typei (TpLambda pi pi' x atk body) (just k) | nothing =
    check-tk atk ≫span
    spanM-add (punctuation-span "Lambda (type)" pi (posinfo-plus pi 1)) ≫span
    get-ctxt λ Γ →
@@ -1633,14 +1633,14 @@ check-typei (TpLambda pi pi' x atk body) (just k) | nothing =
 check-typei (TpLambda pi pi' x atk body) nothing =
   spanM-add (punctuation-span "Lambda (type)" pi (posinfo-plus pi 1)) ≫span
   check-tk atk ≫span
-  add-tk pi' x atk ≫=span λ mi → 
+  add-tk pi' x atk ≫=span λ mi →
   check-type body nothing ≫=span
   cont ≫=span λ mk →
   spanM-restore-info x mi ≫span
   spanMr mk
 
   where cont : maybe kind → spanM (maybe kind)
-        cont nothing = 
+        cont nothing =
           spanM-add (TpLambda-span pi x atk body synthesizing [] nothing) ≫span
           spanMr nothing
         cont (just k) =
@@ -1651,18 +1651,18 @@ check-typei (TpLambda pi pi' x atk body) nothing =
           spanM-add (TpLambda-span pi x atk' body synthesizing [ kind-data Γ r ] nothing) ≫span
           spanMr (just r)
 
-check-typei (Abs pi b {- All or Pi -} pi' x atk body) k = 
+check-typei (Abs pi b {- All or Pi -} pi' x atk body) k =
   get-ctxt λ Γ →
   spanM-add (uncurry (TpQuant-span (me-unerased b) pi x atk body (maybe-to-checking k))
                (if-check-against-star-data Γ "A type-level quantification" k)) ≫span
   spanM-add (punctuation-span "Forall" pi (posinfo-plus pi 1)) ≫span
   check-tk atk ≫span
-  add-tk pi' x atk ≫=span λ mi → 
+  add-tk pi' x atk ≫=span λ mi →
   check-type body (just star) ≫span
   spanM-restore-info x mi ≫span
   return-star-when k
 
-check-typei (TpArrow t1 _ t2) k = 
+check-typei (TpArrow t1 _ t2) k =
   get-ctxt λ Γ →
   spanM-add (uncurry (TpArrow-span t1 t2 (maybe-to-checking k)) (if-check-against-star-data Γ "An arrow type" k)) ≫span
   check-type t1 (just star) ≫span
@@ -1672,27 +1672,27 @@ check-typei (TpArrow t1 _ t2) k =
 check-typei (TpAppt tp t) k =
   check-type tp nothing ≫=span cont'' ≫=spanr cont' k
   where cont : kind → spanM (maybe kind)
-        cont (KndTpArrow tp' k') = 
-          check-term t (just tp') ≫span 
+        cont (KndTpArrow tp' k') =
+          check-term t (just tp') ≫span
           spanMr (just k')
-        cont (KndPi _ _ x (Tkt tp') k') = 
-          check-term t (just tp') ≫span 
-          get-ctxt λ Γ → 
+        cont (KndPi _ _ x (Tkt tp') k') =
+          check-term t (just tp') ≫span
+          get-ctxt λ Γ →
           spanMr (just (subst Γ (qualif-term Γ t) x k'))
         cont k' =
-          get-ctxt λ Γ → 
+          get-ctxt λ Γ →
           spanM-add (TpAppt-span tp t (maybe-to-checking k)
             (type-app-head Γ tp :: head-kind Γ k' :: [ term-argument Γ t ])
             (just ("The kind computed for the head of the type application does"
                 ^ " not allow the head to be applied to an argument which is a term"))) ≫span
           spanMr nothing
         cont' : (outer : maybe kind) → kind → spanM (check-ret outer)
-        cont' nothing k = 
+        cont' nothing k =
           get-ctxt λ Γ →
           spanM-add (TpAppt-span tp t synthesizing [ kind-data Γ k ] nothing) ≫span
           check-type-return Γ k
-        cont' (just k') k = 
-          get-ctxt λ Γ → 
+        cont' (just k') k =
+          get-ctxt λ Γ →
           if conv-kind Γ k k'
             then spanM-add (TpAppt-span tp t checking (expected-kind Γ k' :: [ kind-data Γ k ]) nothing)
             else spanM-add (TpAppt-span tp t checking (expected-kind Γ k' :: [ kind-data Γ k ])
@@ -1704,27 +1704,27 @@ check-typei (TpAppt tp t) k =
 check-typei (TpApp tp tp') k =
   check-type tp nothing ≫=span cont'' ≫=spanr cont' k
   where cont : kind → spanM (maybe kind)
-        cont (KndArrow k'' k') = 
-          check-type tp' (just k'') ≫span 
+        cont (KndArrow k'' k') =
+          check-type tp' (just k'') ≫span
           spanMr (just k')
-        cont (KndPi _ _ x (Tkk k'') k') = 
-          check-type tp' (just k'') ≫span 
-          get-ctxt λ Γ → 
+        cont (KndPi _ _ x (Tkk k'') k') =
+          check-type tp' (just k'') ≫span
+          get-ctxt λ Γ →
           spanMr (just (subst Γ (qualif-type Γ tp') x k'))
         cont k' =
-          get-ctxt λ Γ → 
+          get-ctxt λ Γ →
           spanM-add (TpApp-span tp tp' (maybe-to-checking k)
             (type-app-head Γ tp :: head-kind Γ k' :: [ type-argument Γ tp' ])
             (just ("The kind computed for the head of the type application does"
                 ^ " not allow the head to be applied to an argument which is a type"))) ≫span
           spanMr nothing
         cont' : (outer : maybe kind) → kind → spanM (check-ret outer)
-        cont' nothing k = 
-          get-ctxt λ Γ → 
+        cont' nothing k =
+          get-ctxt λ Γ →
           spanM-add (TpApp-span tp tp' synthesizing [ kind-data Γ k ] nothing) ≫span
           check-type-return Γ k
-        cont' (just k') k = 
-          get-ctxt λ Γ → 
+        cont' (just k') k =
+          get-ctxt λ Γ →
           if conv-kind Γ k k'
             then spanM-add (TpApp-span tp tp' checking (expected-kind Γ k' :: [ kind-data Γ k' ]) nothing)
             else spanM-add (TpApp-span tp tp' checking (expected-kind Γ k' :: [ kind-data Γ k ])
@@ -1733,37 +1733,37 @@ check-typei (TpApp tp tp') k =
         cont'' nothing = spanM-add (TpApp-span tp tp' (maybe-to-checking k) [] nothing) ≫span spanMr nothing
         cont'' (just k) = cont k
 
-check-typei (TpEq pi t1 t2 pi') k = 
-  get-ctxt (λ Γ → 
+check-typei (TpEq pi t1 t2 pi') k =
+  get-ctxt (λ Γ →
   untyped-term-spans t1 ≫span
-  set-ctxt Γ ≫span 
+  set-ctxt Γ ≫span
   untyped-term-spans t2 ≫span
-  set-ctxt Γ) ≫span 
-  get-ctxt λ Γ → 
+  set-ctxt Γ) ≫span
+  get-ctxt λ Γ →
   spanM-add (uncurry (TpEq-span pi t1 t2 pi' (maybe-to-checking k)) (if-check-against-star-data Γ "An equation" k)) ≫span
   -- spanM-add (unchecked-term-span t1) ≫span
   -- spanM-add (unchecked-term-span t2) ≫span
   return-star-when k
 
-check-typei (Lft pi pi' X t l) k = 
-  add-tk pi' X (Tkk star) ≫=span λ mi → 
+check-typei (Lft pi pi' X t l) k =
+  add-tk pi' X (Tkk star) ≫=span λ mi →
   get-ctxt λ Γ → check-term t (just (qualif-type Γ (liftingType-to-type X l))) ≫span
   spanM-add (punctuation-span "Lift" pi (posinfo-plus pi 1)) ≫span
   spanM-restore-info X mi ≫span
   cont k (qualif-kind Γ (liftingType-to-kind l))
   where cont : (outer : maybe kind) → kind → spanM (check-ret outer)
         cont nothing k = get-ctxt λ Γ → spanM-add (Lft-span pi X t synthesizing [ kind-data Γ k ] nothing) ≫span spanMr (just k)
-        cont (just k') k = 
-          get-ctxt λ Γ → 
-          if conv-kind Γ k k' then 
+        cont (just k') k =
+          get-ctxt λ Γ →
+          if conv-kind Γ k k' then
               spanM-add (Lft-span pi X t checking ( expected-kind Γ k' :: [ kind-data Γ k ]) nothing)
             else
               spanM-add (Lft-span pi X t checking ( expected-kind Γ k' :: [ kind-data Γ k ]) (just "The expected kind does not match the computed kind."))
 check-typei (Iota pi pi' x t1 t2) mk =
-  get-ctxt λ Γ → 
+  get-ctxt λ Γ →
   spanM-add (uncurry (Iota-span pi t2 (maybe-to-checking mk)) (if-check-against-star-data Γ "A iota-type" mk)) ≫span
   check-typei t1 (just star) ≫span
-  add-tk pi' x (Tkt t1) ≫=span λ mi → 
+  add-tk pi' x (Tkt t1) ≫=span λ mi →
   check-typei t2 (just star) ≫span
   spanM-restore-info x mi ≫span
   return-star-when mk
@@ -1783,7 +1783,7 @@ check-typei (TpLet pi d T) mk =
 
   finish : var × restore-def → spanM (check-ret mk)
   finish (x , m) =
-    get-ctxt λ Γ → 
+    get-ctxt λ Γ →
     spanM-add (TpLet-span Γ (maybe-to-checking mk) pi d T [] nothing) ≫span
     check-type T mk ≫=span λ r →
     spanM-restore-info x m ≫span
@@ -1801,7 +1801,7 @@ check-kind (KndVar pi x ys) =
         (just "Undefined kind variable")))
     λ ps-as → check-args-against-params nothing (pi , x) -- Isn't used vvvv
       (fst $ snd $ elim-pair ps-as λ ps as → subst-params-args Γ ps as star) ys
- 
+
   {-helper (ctxt-lookup-kind-var-def-args Γ x)
   where helper : maybe (params × args) → spanM ⊤
         helper (just (ps , as)) = check-args-against-params nothing (pi , x) ps (append-args as ys)
@@ -1809,19 +1809,19 @@ check-kind (KndVar pi x ys) =
           spanM-add (KndVar-span Γ (pi , x) (kvar-end-pos pi x ys) ParamsNil checking []
             (just "Undefined kind variable"))-}
 
-check-kind (KndArrow k k') = 
+check-kind (KndArrow k k') =
   spanM-add (KndArrow-span k k' checking nothing) ≫span
   check-kind k ≫span
   check-kind k'
-check-kind (KndTpArrow t k) = 
+check-kind (KndTpArrow t k) =
   spanM-add (KndTpArrow-span t k checking nothing) ≫span
   check-type t (just star) ≫span
   check-kind k
-check-kind (KndPi pi pi' x atk k) = 
+check-kind (KndPi pi pi' x atk k) =
   spanM-add (punctuation-span "Pi (kind)" pi (posinfo-plus pi 1)) ≫span
   spanM-add (KndPi-span pi x atk k checking nothing) ≫span
   check-tk atk ≫span
-  add-tk pi' x atk ≫=span λ mi → 
+  add-tk pi' x atk ≫=span λ mi →
   check-kind k ≫span
   spanM-restore-info x mi
 
@@ -1845,11 +1845,11 @@ check-args-against-params kind-or-import orig ps ys =
     check-erased-margs t (just T') ≫span
     caap ff ps ys (trie-insert σ x $ TermArg NotErased (qualif-term Γ t))
   caap ff (ParamsCons (Decl _ pi Erased x (Tkt T) _) ps) (ArgsCons (TermArg NotErased t) ys) σ =
-    get-ctxt λ Γ → 
+    get-ctxt λ Γ →
     spanM-add (make-span Γ [ term-argument Γ t ]
                  (just ("A term argument was supplied for erased term parameter " ^ unqual-local x)))
   caap ff (ParamsCons (Decl _ pi NotErased x (Tkt T) _) ps) (ArgsCons (TermArg Erased t) ys) σ =
-    get-ctxt λ Γ → 
+    get-ctxt λ Γ →
     spanM-add (make-span Γ [ term-argument Γ t ]
                  (just ("An erased term argument was supplied for term parameter " ^ unqual-local x)))
   -- Either a kind argument or a correctly erased module argument
@@ -1858,21 +1858,21 @@ check-args-against-params kind-or-import orig ps ys =
     check-term t (just (substs Γ σ T)) ≫span
     caap koi ps ys (trie-insert σ x $ TermArg me (qualif-term Γ t))
   caap koi (ParamsCons (Decl _ x₁ _ x (Tkk x₃) x₄) ps₁) (ArgsCons (TermArg _ x₅) ys₂) σ =
-    get-ctxt λ Γ → 
+    get-ctxt λ Γ →
     spanM-add (make-span Γ [ term-argument Γ x₅ ]
                  (just ("A term argument was supplied for type parameter " ^ unqual-local x)))
-  caap koi (ParamsCons (Decl _ x₁ _ x (Tkt x₃) x₄) ps₁) (ArgsCons (TypeArg x₅) ys₂) σ = 
-    get-ctxt λ Γ → 
+  caap koi (ParamsCons (Decl _ x₁ _ x (Tkt x₃) x₄) ps₁) (ArgsCons (TypeArg x₅) ys₂) σ =
+    get-ctxt λ Γ →
     spanM-add (make-span Γ [ type-argument Γ x₅ ]
                  (just ("A type argument was supplied for term parameter " ^ unqual-local x)))
   caap tt (ParamsCons (Decl _ _ _ x _ _) ps₁) ArgsNil σ =
-    get-ctxt λ Γ → 
+    get-ctxt λ Γ →
     spanM-add (make-span Γ []
                  (just ("Missing an argument for parameter " ^ unqual-local x)))
   caap ff (ParamsCons (Decl _ _ _ x _ _) ps₁) ArgsNil σ =
     get-ctxt λ Γ → spanM-add (make-span Γ [] nothing)
-  caap koi ParamsNil (ArgsCons x₁ ys₂) σ = 
-    get-ctxt λ Γ → 
+  caap koi ParamsNil (ArgsCons x₁ ys₂) σ =
+    get-ctxt λ Γ →
     spanM-add (make-span Γ [ arg-argument Γ x₁ ]
                  (just "An extra argument was given"))
   caap koi ParamsNil ArgsNil σ =
@@ -1893,7 +1893,7 @@ check-def (DefTerm pi₁ x NoType t') =
   cont : 𝕃 tagged-val × err-m → term → maybe type → spanM (var × restore-def)
   cont (tvs , err) t' (just T) =
     spanM-push-term-def pi₁ x t' T ≫=span λ m →
-    get-ctxt λ Γ → 
+    get-ctxt λ Γ →
     spanM-add (Var-span Γ pi₁ x synthesizing (type-data Γ T :: noterased :: tvs) err) ≫span
     spanMr (x , m)
   cont (tvs , err) t' nothing = spanM-push-term-udef pi₁ x t' ≫=span λ m →
@@ -1904,7 +1904,7 @@ check-def (DefTerm pi₁ x (SomeType T) t') =
   check-type T (just star) ≫span
   get-ctxt λ Γ →
   let T' = qualif-type Γ T in
-  check-term t' (just T') ≫span 
+  check-term t' (just T') ≫span
   spanM-push-term-def pi₁ x t' T' ≫=span λ m →
   get-ctxt λ Γ →
   let p = compileFail-in Γ t' in

--- a/src/constants.agda
+++ b/src/constants.agda
@@ -25,5 +25,5 @@ options-file-name = "options"
 global-error-string : string → string
 global-error-string msg = "{\"error\":\"" ^ msg ^ "\"" ^ "}"
 
-dot-cedille-directory : string → string 
+dot-cedille-directory : string → string
 dot-cedille-directory dir = combineFileNames dir ".cedille"

--- a/src/conversion.agda
+++ b/src/conversion.agda
@@ -68,23 +68,23 @@ conv-t T = ctxt → T → T → 𝔹
 -- main entry point
 -- does not assume erased
 conv-term : conv-t term
-conv-type : conv-t type 
+conv-type : conv-t type
 conv-kind : conv-t kind
 
 -- assume erased
-conv-terme : conv-t term 
-conv-argse : conv-t (𝕃 term) 
+conv-terme : conv-t term
+conv-argse : conv-t (𝕃 term)
 conv-typee : conv-t type
 conv-kinde : conv-t kind
 
 -- call hnf, then the conv-X-norm functions
-conv-term' : conv-t term 
-conv-type' : conv-t type 
+conv-term' : conv-t term
+conv-type' : conv-t type
 
-hnf : {ed : exprd} → ctxt → (u : unfolding) → ⟦ ed ⟧ → (is-head : 𝔹) → ⟦ ed ⟧ 
+hnf : {ed : exprd} → ctxt → (u : unfolding) → ⟦ ed ⟧ → (is-head : 𝔹) → ⟦ ed ⟧
 
 -- assume head normalized inputs
-conv-term-norm : conv-t term 
+conv-term-norm : conv-t term
 conv-type-norm : conv-t type
 conv-kind-norm : conv-t kind
 
@@ -109,7 +109,7 @@ conv-ttye* : conv-t (𝕃 tty)
 conv-term Γ t t' = conv-terme Γ (erase t) (erase t')
 
 conv-terme Γ t t' with decompose-apps t | decompose-apps t'
-conv-terme Γ t t' | Var _ x , args | Var _ x' , args' = 
+conv-terme Γ t t' | Var _ x , args | Var _ x' , args' =
   if ctxt-eq-rep Γ x x' && conv-argse Γ args args' then tt else
   conv-term' Γ t t'
 conv-terme Γ t t' | _ | _ = conv-term' Γ t t'
@@ -121,7 +121,7 @@ conv-argse Γ _ _ = ff
 conv-type Γ t t' = conv-typee Γ (erase t) (erase t')
 
 conv-typee Γ t t' with decompose-tpapps t | decompose-tpapps t'
-conv-typee Γ t t' | TpVar _ x , args | TpVar _ x' , args' = 
+conv-typee Γ t t' | TpVar _ x , args | TpVar _ x' , args' =
   if ctxt-eq-rep Γ x x' && conv-tty* Γ args args' then tt else
   conv-type' Γ t t'
 conv-typee Γ t t' | _ | _ = conv-type' Γ t t'
@@ -143,11 +143,11 @@ hnf{TERM} Γ u (Lam _ Erased _ _ _ t) hd = hnf Γ u t hd
 hnf{TERM} Γ u (Lam _ NotErased _ x oc t) hd with hnf (ctxt-var-decl x Γ) u t hd
 hnf{TERM} Γ u (Lam _ NotErased _ x oc t) hd | (App t' NotErased (Var _ x')) with x =string x' && ~ (is-free-in skip-erased x t')
 hnf{TERM} Γ u (Lam _ NotErased _ x oc t) hd | (App t' NotErased (Var _ x')) | tt = t' -- eta-contraction
-hnf{TERM} Γ u (Lam _ NotErased _ x oc t) hd | (App t' NotErased (Var _ x')) | ff = 
+hnf{TERM} Γ u (Lam _ NotErased _ x oc t) hd | (App t' NotErased (Var _ x')) | ff =
   Lam posinfo-gen NotErased posinfo-gen x NoClass (App t' NotErased (Var posinfo-gen x'))
 hnf{TERM} Γ u (Lam _ NotErased _ x oc t) hd | t' = Lam posinfo-gen NotErased posinfo-gen x NoClass t'
-hnf{TERM} Γ u (Let _ (DefTerm _ x _ t) t') hd = hnf Γ u (subst Γ t x t') hd 
-hnf{TERM} Γ u (Let _ (DefType _ x _ _) t') hd = hnf (ctxt-var-decl x Γ) u t' hd 
+hnf{TERM} Γ u (Let _ (DefTerm _ x _ t) t') hd = hnf Γ u (subst Γ t x t') hd
+hnf{TERM} Γ u (Let _ (DefType _ x _ _) t') hd = hnf (ctxt-var-decl x Γ) u t' hd
 hnf{TERM} Γ (unfold _ _ _ _) (Var _ x) hd with ctxt-lookup-term-var-def Γ x
 hnf{TERM} Γ (unfold _ _ _ _) (Var _ x) hd | nothing = Var posinfo-gen x
 hnf{TERM} Γ (unfold ff _ _ e) (Var _ x) hd | just t = erase-if e t -- definitions should be stored in hnf
@@ -170,7 +170,7 @@ hnf{TERM} Γ u x hd = x
 hnf{TYPE} Γ no-unfolding e _ = e
 hnf{TYPE} Γ u (TpParens _ t _) hd = hnf Γ u t hd
 hnf{TYPE} Γ u (NoSpans t _)  hd = hnf Γ u t hd
-hnf{TYPE} Γ (unfold b b' _ _) (TpVar _ x) ff  = TpVar posinfo-gen x 
+hnf{TYPE} Γ (unfold b b' _ _) (TpVar _ x) ff  = TpVar posinfo-gen x
 hnf{TYPE} Γ (unfold b b' _ _) (TpVar _ x) tt with ctxt-lookup-type-var-def Γ x
 hnf{TYPE} Γ (unfold b b' _ _) (TpVar _ x) tt | just tp = tp
 hnf{TYPE} Γ (unfold b b' _ _) (TpVar _ x) tt | nothing = TpVar posinfo-gen x
@@ -178,8 +178,8 @@ hnf{TYPE} Γ u (TpAppt tp t) hd with hnf Γ u tp hd
 hnf{TYPE} Γ u (TpAppt _ t) hd  | TpLambda _ _ x _ tp = hnf Γ u (subst Γ t x tp) hd
 hnf{TYPE} Γ u (TpAppt _ t) hd | tp = TpAppt tp (erase-if (unfolding-get-erased u) t)
 hnf{TYPE} Γ u (TpApp tp tp') hd with hnf Γ u tp hd
-hnf{TYPE} Γ u (TpApp _ tp') hd | TpLambda _ _ x _ tp = hnf Γ u (subst Γ tp' x tp) hd 
-hnf{TYPE} Γ u (TpApp _ tp') hd | tp with hnf Γ u tp' hd 
+hnf{TYPE} Γ u (TpApp _ tp') hd | TpLambda _ _ x _ tp = hnf Γ u (subst Γ tp' x tp) hd
+hnf{TYPE} Γ u (TpApp _ tp') hd | tp with hnf Γ u tp' hd
 hnf{TYPE} Γ u (TpApp _ _) hd | tp | tp' = try-pull-lift-types tp tp'
 
   {- given (T1 T2), with T1 and T2 types, see if we can pull a lifting operation from the heads of T1 and T2 to
@@ -193,17 +193,17 @@ hnf{TYPE} Γ u (TpApp _ _) hd | tp | tp' = try-pull-lift-types tp tp'
             TpApp tp1 tp2
 
           where try-pull-term-in : ctxt → term → liftingType → ℕ → 𝕃 var → 𝕃 liftingType → type
-                try-pull-term-in Γ t (LiftParens _ l _) n vars ltps = try-pull-term-in Γ t l n vars ltps 
-                try-pull-term-in Γ t (LiftArrow _ l) 0 vars ltps = 
-                  recompose-tpapps 
+                try-pull-term-in Γ t (LiftParens _ l _) n vars ltps = try-pull-term-in Γ t l n vars ltps
+                try-pull-term-in Γ t (LiftArrow _ l) 0 vars ltps =
+                  recompose-tpapps
                     (Lft posinfo-gen posinfo-gen X
                       (Lam* vars (hnf Γ no-unfolding (App t NotErased (App* t' (map (λ v → NotErased , mvar v) vars))) tt))
                       (LiftArrow* ltps l) , args1)
                 try-pull-term-in Γ (Lam _ _ _ x _ t) (LiftArrow l1 l2) (suc n) vars ltps =
-                  try-pull-term-in (ctxt-var-decl x Γ) t l2 n (x :: vars) (l1 :: ltps) 
+                  try-pull-term-in (ctxt-var-decl x Γ) t l2 n (x :: vars) (l1 :: ltps)
                 try-pull-term-in Γ t (LiftArrow l1 l2) (suc n) vars ltps =
                   let x = fresh-var "x" (ctxt-binds-var Γ) empty-renamectxt in
-                    try-pull-term-in (ctxt-var-decl x Γ) (App t NotErased (mvar x)) l2 n (x :: vars) (l1 :: ltps) 
+                    try-pull-term-in (ctxt-var-decl x Γ) (App t NotErased (mvar x)) l2 n (x :: vars) (l1 :: ltps)
                 try-pull-term-in Γ t l n vars ltps = TpApp tp1 tp2
 
         try-pull-lift-types tp1 tp2 | _ | _ = TpApp tp1 tp2
@@ -218,9 +218,9 @@ hnf{TYPE} Γ u (Abs _ _ _ _ _ _) _ | tp'' | nothing = tp''
 hnf{TYPE} Γ u (TpArrow tp1 arrowtype tp2) _ = TpArrow (hnf Γ u tp1 ff) arrowtype (hnf Γ u tp2 ff)
 hnf{TYPE} Γ u (TpEq _ t1 t2 _) _
   = TpEq posinfo-gen (erase t1) (erase t2) posinfo-gen
-hnf{TYPE} Γ u (TpLambda _ _ x atk tp) _ = 
+hnf{TYPE} Γ u (TpLambda _ _ x atk tp) _ =
   TpLambda posinfo-gen posinfo-gen x (hnf Γ u atk ff) (hnf (ctxt-var-decl x Γ) u tp ff)
-hnf{TYPE} Γ u @ (unfold b tt b'' b''') (Lft _ _ y t l) _ = 
+hnf{TYPE} Γ u @ (unfold b tt b'' b''') (Lft _ _ y t l) _ =
  let t = hnf (ctxt-var-decl y Γ) u t tt in
    do-lift Γ (Lft posinfo-gen posinfo-gen y t l) y l (λ t → hnf{TERM} Γ unfold-head t ff) t
 -- We need hnf{TYPE} to preserve types' well-kindedness, so we must check if
@@ -241,7 +241,7 @@ hnf{TYPE} Γ u x _ = x
 
 hnf{KIND} Γ no-unfolding e hd = e
 hnf{KIND} Γ u (KndParens _ k _) hd = hnf Γ u k hd
-hnf{KIND} Γ (unfold _ _ _ _) (KndVar _ x ys) _ with ctxt-lookup-kind-var-def Γ x 
+hnf{KIND} Γ (unfold _ _ _ _) (KndVar _ x ys) _ with ctxt-lookup-kind-var-def Γ x
 ... | nothing = KndVar posinfo-gen x ys
 ... | just (ps , k) = fst $ subst-params-args Γ ps ys k {- do-subst ys ps k
   where do-subst : args → params → kind → kind
@@ -274,7 +274,7 @@ hanf : ctxt → (e : 𝔹) → term → term
 hanf Γ e t with hnf Γ (unfolding-set-erased unfold-head-one e) t tt
 hanf Γ e t | t' with decompose-apps t'
 hanf Γ e t | t' | (Var _ x) , [] = t'
-hanf Γ e t | t' | (Var _ x) , args with ctxt-lookup-term-var-def Γ x 
+hanf Γ e t | t' | (Var _ x) , args with ctxt-lookup-term-var-def Γ x
 hanf Γ e t | t' | (Var _ x) , args | nothing = t'
 hanf Γ e t | t' | (Var _ x) , args | just _ = hanf Γ e t'
 hanf Γ e t | t' | h , args {- h could be a Lambda if args is [] -} = t
@@ -299,7 +299,7 @@ conv-term-norm Γ _ (Hole _) = tt
    We implement this here by implicitly eta-expanding the variable and continuing
    the comparison.
 
-   A simple example is 
+   A simple example is
 
        λ v . t ((λ a . a) v) ≃ t
  -}
@@ -308,25 +308,25 @@ conv-term-norm Γ (Lam _ l _ x oc t) t' =
   conv-term (ctxt-rename x x' Γ) t (App t' NotErased (Var posinfo-gen x'))
 conv-term-norm Γ t' (Lam _ l _ x oc t) =
   let x' = fresh-var x (ctxt-binds-var Γ) empty-renamectxt in
-  conv-term (ctxt-rename x x' Γ) (App t' NotErased (Var posinfo-gen x')) t 
+  conv-term (ctxt-rename x x' Γ) (App t' NotErased (Var posinfo-gen x')) t
 conv-term-norm Γ _ _ = ff
 
 conv-type-norm Γ (TpVar _ x) (TpVar _ x') = ctxt-eq-rep Γ x x'
 conv-type-norm Γ (TpApp t1 t2) (TpApp t1' t2') = conv-type-norm Γ t1 t1' && conv-type Γ t2 t2'
 conv-type-norm Γ (TpAppt t1 t2) (TpAppt t1' t2') = conv-type-norm Γ t1 t1' && conv-term Γ t2 t2'
-conv-type-norm Γ (Abs _ b _ x atk tp) (Abs _ b' _ x' atk' tp') = 
+conv-type-norm Γ (Abs _ b _ x atk tp) (Abs _ b' _ x' atk' tp') =
   eq-maybeErased b b' && conv-tk Γ atk atk' && conv-type (ctxt-rename x x' (ctxt-var-decl-if x' Γ)) tp tp'
 conv-type-norm Γ (TpArrow tp1 a1 tp2) (TpArrow tp1' a2  tp2') = eq-maybeErased a1 a2 && conv-type Γ tp1 tp1' && conv-type Γ tp2 tp2'
 conv-type-norm Γ (TpArrow tp1 a tp2) (Abs _ b _ _ (Tkt tp1') tp2') = eq-maybeErased a b && conv-type Γ tp1 tp1' && conv-type Γ tp2 tp2'
 conv-type-norm Γ (Abs _ b _ _ (Tkt tp1) tp2) (TpArrow tp1' a tp2') = eq-maybeErased a b && conv-type Γ tp1 tp1' && conv-type Γ tp2 tp2'
-conv-type-norm Γ (Iota _ _ x m tp) (Iota _ _ x' m' tp') = 
+conv-type-norm Γ (Iota _ _ x m tp) (Iota _ _ x' m' tp') =
   conv-type Γ m m' && conv-type (ctxt-rename x x' (ctxt-var-decl-if x' Γ)) tp tp'
 conv-type-norm Γ (TpEq _ t1 t2 _) (TpEq _ t1' t2' _) = conv-term Γ t1 t1' && conv-term Γ t2 t2'
 conv-type-norm Γ (Lft _ _ x t l) (Lft _ _ x' t' l') =
   conv-liftingType Γ l l' && conv-term (ctxt-rename x x' (ctxt-var-decl-if x' Γ)) t t'
 conv-type-norm Γ (TpLambda _ _ x atk tp) (TpLambda _ _ x' atk' tp') =
   conv-tk Γ atk atk' && conv-type (ctxt-rename x x' (ctxt-var-decl-if x' Γ)) tp tp'
-conv-type-norm Γ _ _ = ff 
+conv-type-norm Γ _ _ = ff
 
 {- even though hnf turns Pi-kinds where the variable is not free in the body into arrow kinds,
    we still need to check off-cases, because normalizing the body of a kind could cause the
@@ -335,7 +335,7 @@ conv-kind-norm Γ (KndArrow k k₁) (KndArrow k' k'') = conv-kind Γ k k' && con
 conv-kind-norm Γ (KndArrow k k₁) (KndPi _ _ x (Tkk k') k'') = conv-kind Γ k k' && conv-kind Γ k₁ k''
 conv-kind-norm Γ (KndArrow k k₁) _ = ff
 conv-kind-norm Γ (KndPi _ _ x (Tkk k₁) k) (KndArrow k' k'') = conv-kind Γ k₁ k' && conv-kind Γ k k''
-conv-kind-norm Γ (KndPi _ _ x atk k) (KndPi _ _ x' atk' k'') = 
+conv-kind-norm Γ (KndPi _ _ x atk k) (KndPi _ _ x' atk' k'') =
     conv-tk Γ atk atk' && conv-kind (ctxt-rename x x' (ctxt-var-decl-if x' Γ)) k k''
 conv-kind-norm Γ (KndPi _ _ x (Tkt t) k) (KndTpArrow t' k'') = conv-type Γ t t' && conv-kind Γ k k''
 conv-kind-norm Γ (KndPi _ _ x (Tkt t) k) _ = ff
@@ -407,7 +407,7 @@ ctxt-kind-def pi v ps2 k Γ@(mk-ctxt (fn , mn , ps1 , q) (syms , mn-fn) i symb-o
 -- assumption: classifier (i.e. kind) already qualified
 ctxt-datatype-def : posinfo → var → params → kind → defDatatype → ctxt → ctxt
 ctxt-datatype-def pi v pa k dd Γ@(mk-ctxt (fn , mn , ps , q) (syms , mn-fn) i symb-occs d) = mk-ctxt
-  (fn , mn , ps , q') 
+  (fn , mn , ps , q')
   ((trie-insert-append2 syms fn mn v) , mn-fn)
   (trie-insert i v' (datatype-def pa k , fn , pi))
   symb-occs
@@ -432,7 +432,7 @@ ctxt-type-def pi s op v t k Γ@(mk-ctxt (fn , mn , ps , q) (syms , mn-fn) i symb
 ctxt-const-def : posinfo → var → type → ctxt → ctxt
 ctxt-const-def pi c t Γ@(mk-ctxt mod@(fn , mn , ps , q) (syms , mn-fn) i symb-occs d) = mk-ctxt
   (fn , mn , ps , q')
-  ((trie-insert-append2 syms fn mn c) , mn-fn)  
+  ((trie-insert-append2 syms fn mn c) , mn-fn)
   (trie-insert i c' (const-def t , fn , pi))
   symb-occs
   d

--- a/src/ctxt-types.agda
+++ b/src/ctxt-types.agda
@@ -6,7 +6,7 @@ open import general-util
 open import syntax-util
 
 location : Set
-location = string × posinfo -- file path and starting position in the file 
+location = string × posinfo -- file path and starting position in the file
 
 -- file path and starting / ending position in file
 span-location = string × posinfo × posinfo
@@ -46,7 +46,7 @@ data ctxt-info : Set where
   -- for defining a variable to equal a term with a given type
   term-def : defParams → opacity → term → type → ctxt-info
 
-  -- for untyped term definitions 
+  -- for untyped term definitions
   term-udef : defParams → opacity → term → ctxt-info
 
   -- for declaring a variable to have a given kind (with no definition)
@@ -87,7 +87,7 @@ data ctxt : Set where
             (syms : trie (string × 𝕃 string) × trie string × trie params × trie ℕ × Σ ℕ (𝕍 string)) →    -- map each filename to its module name and the symbols declared in that file, map each module name to its filename and params, and file ID's for use in to-string.agda
             (i : trie sym-info) →                  -- map symbols (from Cedille files) to their ctxt-info and location
             (sym-occurrences : trie (𝕃 (var × posinfo × string))) →  -- map symbols to a list of definitions they occur in (and relevant file info)
-            (datatypes-info : trie datatype-info) → 
+            (datatypes-info : trie datatype-info) →
             ctxt
 
 
@@ -127,4 +127,3 @@ ctxt-get-symbol-occurrences (mk-ctxt _ _ _ symb-occs _) = symb-occs
 
 ctxt-set-symbol-occurrences : ctxt → trie (𝕃 (var × posinfo × string)) → ctxt
 ctxt-set-symbol-occurrences (mk-ctxt fn syms i symb-occs d) new-symb-occs = mk-ctxt fn syms i new-symb-occs d
-

--- a/src/ctxt.agda
+++ b/src/ctxt.agda
@@ -103,7 +103,7 @@ ctxt-type-decl p v k Γ@(mk-ctxt (fn , mn , ps , q) syms i symb-occs d) =
   where v' = p % v
 
 ctxt-tk-decl : posinfo → var → tk → ctxt → ctxt
-ctxt-tk-decl p x (Tkt t) Γ = ctxt-term-decl p x t Γ 
+ctxt-tk-decl p x (Tkt t) Γ = ctxt-term-decl p x t Γ
 ctxt-tk-decl p x (Tkk k) Γ = ctxt-type-decl p x k Γ
 
 -- TODO not sure how this and renaming interacts with module scope
@@ -118,7 +118,7 @@ ctxt-var-decl-if v Γ with Γ
   d
 
 ctxt-rename-rep : ctxt → var → var
-ctxt-rename-rep (mk-ctxt m syms i _ _) v with trie-lookup i v 
+ctxt-rename-rep (mk-ctxt m syms i _ _) v with trie-lookup i v
 ...                                           | just (rename-def v' , _) = v'
 ...                                           | _ = v
 
@@ -309,4 +309,3 @@ unqual (mk-ctxt (_ , _ , _ , q) _ _ _  _) v =
   if qualif-nonempty q
   then unqual-local (unqual-all q v)
   else v
-

--- a/src/cws-main.agda
+++ b/src/cws-main.agda
@@ -22,7 +22,7 @@ putStrRunIf : 𝔹 → Run → IO ⊤
 putStrRunIf tt r = putStr (Run-to-string r) >> putStr "\n"
 putStrRunIf ff r = return triv
 
-processArgs : (showRun : 𝔹) → (showParsed : 𝔹) → 𝕃 string → IO ⊤ 
+processArgs : (showRun : 𝔹) → (showParsed : 𝔹) → 𝕃 string → IO ⊤
 processArgs showRun showParsed (input-filename :: []) = (readFiniteFile input-filename) >>= processText
   where processText : string → IO ⊤
         processText x with runRtn (string-to-𝕃char x)
@@ -31,12 +31,11 @@ processArgs showRun showParsed (input-filename :: []) = (readFiniteFile input-fi
         processText x | s | inj₂ r with putStrRunIf showRun r | rewriteRun r
         processText x | s | inj₂ r | sr | r' with putStrRunIf showParsed r'
         processText x | s | inj₂ r | sr | r' | sr' = sr >> sr' >> putStr (process r')
-                                     
-processArgs showRun showParsed ("--showRun" :: xs) = processArgs tt showParsed xs 
-processArgs showRun showParsed ("--showParsed" :: xs) = processArgs showRun tt xs 
+
+processArgs showRun showParsed ("--showRun" :: xs) = processArgs tt showParsed xs
+processArgs showRun showParsed ("--showParsed" :: xs) = processArgs showRun tt xs
 processArgs showRun showParsed (x :: xs) = putStr ("Unknown option " ^ x ^ "\n")
 processArgs showRun showParsed [] = putStr "Please run with the name of a file to process.\n"
 
 main : IO ⊤
 main = getArgs >>= processArgs ff ff
-

--- a/src/cws-types.agda
+++ b/src/cws-types.agda
@@ -11,18 +11,18 @@ posinfo = string
 
 {-# FOREIGN GHC import qualified CedilleCommentsLexer #-}
 
-data entity : Set where 
+data entity : Set where
     EntityComment : posinfo → posinfo → entity
     EntityNonws : entity
     EntityWs : posinfo → posinfo → entity
 {-# COMPILE GHC entity = data CedilleCommentsLexer.Entity (CedilleCommentsLexer.EntityComment | CedilleCommentsLexer.EntityNonws | CedilleCommentsLexer.EntityWs) #-}
 
-data entities : Set where 
+data entities : Set where
     EndEntity : entities
     Entity : entity → entities → entities
 {-# COMPILE GHC entities = data CedilleCommentsLexer.Entities (CedilleCommentsLexer.EndEntity | CedilleCommentsLexer.Entity) #-}
 
-data start : Set where 
+data start : Set where
     File : entities → start
 {-# COMPILE GHC start = data CedilleCommentsLexer.Start (CedilleCommentsLexer.File) #-}
 
@@ -254,4 +254,3 @@ isParseTree p l s = ⊤ {- this will be ignored since we are using simply typed 
 
 ptr : ParseTreeRec
 ptr = record { ParseTreeT = ParseTreeT ; isParseTree = isParseTree ; ParseTreeToString = ParseTreeToString }
-

--- a/src/elaboration-helpers.agda
+++ b/src/elaboration-helpers.agda
@@ -317,10 +317,10 @@ module reindexing (Γ : ctxt) (isₒ : indices) where
        let x' = reindex-fresh-var ρ is x in
        Index x' (substh-tk {TERM} Γ ρ empty-trie atk) :: f (renamectxt-insert ρ x x')})
     (λ ρ → []) isₒ ρ
-  
+
   reindex-t : Set → Set
   reindex-t X = renamectxt → trie indices → X → X
-  
+
   reindex : ∀ {ed} → reindex-t ⟦ ed ⟧
   reindex-term : reindex-t term
   reindex-type : reindex-t type
@@ -337,7 +337,7 @@ module reindexing (Γ : ctxt) (isₒ : indices) where
   reindex-theta : reindex-t theta
   reindex-vars : reindex-t (maybe vars)
   reindex-defTermOrType : renamectxt → trie indices → defTermOrType → defTermOrType × renamectxt
-  
+
   reindex{TERM} = reindex-term
   reindex{TYPE} = reindex-type
   reindex{KIND} = reindex-kind
@@ -346,12 +346,12 @@ module reindexing (Γ : ctxt) (isₒ : indices) where
 
   rc-is : renamectxt → indices → renamectxt
   rc-is = foldr λ {(Index x atk) ρ → renamectxt-insert ρ x x}
-  
+
   index-var = "indices"
   index-type-var = "Indices"
   is-index-var = isJust ∘ is-pfx index-var
   is-index-type-var = isJust ∘ is-pfx index-type-var
-  
+
   reindex-term ρ is (App t me (Var pi x)) with trie-lookup is x
   ...| nothing = App (reindex-term ρ is t) me (reindex-term ρ is (Var pi x))
   ...| just is' = indices-to-apps is' $ reindex-term ρ is t
@@ -396,8 +396,8 @@ module reindexing (Γ : ctxt) (isₒ : indices) where
   reindex-term ρ is (Var pi x) =
     Var pi $ renamectxt-rep ρ x
   reindex-term ρ is (Mu pi x t oT pi' cs pi'') = Var posinfo-gen "template-mu-not-allowed"
-  reindex-term ρ is (Mu' pi t oT pi' cs pi'') = Var posinfo-gen "template-mu-not-allowed" 
-  
+  reindex-term ρ is (Mu' pi t oT pi' cs pi'') = Var posinfo-gen "template-mu-not-allowed"
+
   reindex-type ρ is (Abs pi me pi' x atk T) with is-index-var x
   ...| ff = let x' = reindex-fresh-var ρ is x in
     Abs pi me pi' x' (reindex-tk ρ is atk) (reindex-type (renamectxt-insert ρ x x') is T)
@@ -439,7 +439,7 @@ module reindexing (Γ : ctxt) (isₒ : indices) where
     reindex-type ρ is T
   reindex-type ρ is (TpVar pi x) =
     TpVar pi $ renamectxt-rep ρ x
-  
+
   reindex-kind ρ is (KndParens pi k pi') =
     reindex-kind ρ is k
   reindex-kind ρ is (KndArrow k k') =
@@ -459,10 +459,10 @@ module reindexing (Γ : ctxt) (isₒ : indices) where
     KndVar pi (renamectxt-rep ρ x) (reindex-args ρ is as)
   reindex-kind ρ is (Star pi) =
     Star pi
-  
+
   reindex-tk ρ is (Tkt T) = Tkt $ reindex-type ρ is T
   reindex-tk ρ is (Tkk k) = Tkk $ reindex-kind ρ is k
-  
+
   -- Can't reindex large indices in a lifting type (LiftPi requires a type, not a tk),
   -- so for now we will just ignore reindexing lifting types.
   -- Types withing lifting types will still be reindexed, though.
@@ -477,21 +477,21 @@ module reindexing (Γ : ctxt) (isₒ : indices) where
     LiftStar pi
   reindex-liftingType ρ is (LiftTpArrow T lT) =
     LiftTpArrow (reindex-type ρ is T) (reindex-liftingType ρ is lT)
-  
+
   reindex-optTerm ρ is NoTerm = NoTerm
   reindex-optTerm ρ is (SomeTerm t pi) = SomeTerm (reindex-term ρ is t) pi
-  
+
   reindex-optType ρ is NoType = NoType
   reindex-optType ρ is (SomeType T) = SomeType (reindex-type ρ is T)
-  
+
   reindex-optClass ρ is NoClass = NoClass
   reindex-optClass ρ is (SomeClass atk) = SomeClass (reindex-tk ρ is atk)
-  
+
   reindex-optGuide ρ is NoGuide = NoGuide
   reindex-optGuide ρ is (Guide pi x T) =
     let x' = reindex-fresh-var ρ is x in
     Guide pi x' (reindex-type (renamectxt-insert ρ x x') is T)
-  
+
   reindex-lterms ρ is (LtermsNil pi) = LtermsNil pi
   reindex-lterms ρ is (LtermsCons me t ts) =
     LtermsCons me (reindex-term ρ is t) (reindex-lterms ρ is ts)
@@ -513,13 +513,13 @@ module reindexing (Γ : ctxt) (isₒ : indices) where
   reindex-vars ρ is (just (VarsNext x xs)) = maybe-else (reindex-vars ρ is $ just xs)
     (λ xs' → maybe-map (reindex-vars''' xs') $ reindex-vars ρ is $ just xs) $ reindex-vars' ρ is x
   reindex-vars ρ is nothing = nothing
-  
+
   reindex-arg ρ is (TermArg me t) = TermArg me (reindex-term ρ is t)
   reindex-arg ρ is (TypeArg T) = TypeArg (reindex-type ρ is T)
-  
+
   reindex-args ρ is ArgsNil = ArgsNil
   reindex-args ρ is (ArgsCons a as) = ArgsCons (reindex-arg ρ is a) (reindex-args ρ is as)
-  
+
   reindex-defTermOrType ρ is (DefTerm pi x oT t) =
     let x' = reindex-fresh-var ρ is x in
     DefTerm pi x' (reindex-optType ρ is oT) (reindex-term ρ is t) , renamectxt-insert ρ x x'
@@ -625,9 +625,9 @@ record datatype-encoding : Set where
     where
     csn = CmdsNext ∘ flip (DefTermOrType OpacTrans) posinfo-gen
     k = indices-to-kind is $ Star posinfo-gen
-    
+
     Γ' = add-parameters-to-ctxt ps $ add-constructors-to-ctxt cs $ ctxt-var-decl x Γ''
-    
+
     tcs-ρ = reindex-file Γ' is template
     tcs = fst tcs-ρ
     ρ = snd tcs-ρ
@@ -641,7 +641,7 @@ record datatype-encoding : Set where
     fixpoint-inₓ = renamectxt-rep ρ fixpoint-in
     fixpoint-indₓ = renamectxt-rep ρ fixpoint-ind
     Γ = add-indices-to-ctxt is $ ctxt-var-decl data-functorₓ $ ctxt-var-decl data-fmapₓ $ ctxt-var-decl data-functor-indₓ Γ'
-    
+
     new-var : ∀ {ℓ} {X : Set ℓ} → var → (var → X) → X
     new-var x f = f $ fresh-var x (ctxt-binds-var Γ) ρ
 
@@ -682,9 +682,9 @@ record datatype-encoding : Set where
       Abs posinfo-gen Erased posinfo-gen eₓ (Tkt $ mtpeq (mvar yₓ) (mvar xₓ)) $
       TpAppt (indices-to-tpapps is $ mtpvar Xₓ) $
       Phi posinfo-gen (mvar eₓ) (mvar yₓ) (mvar xₓ) posinfo-gen
-    
-    
-    
+
+
+
     fmap-cmd : defTermOrType
     fmap-cmd with new-var "A" id | new-var "B" id | new-var "c" id
     ...| Aₓ | Bₓ | cₓ = DefTerm posinfo-gen data-fmapₓ (SomeType $

--- a/src/elaboration.agda
+++ b/src/elaboration.agda
@@ -55,7 +55,7 @@ mendler-encoding =
           NoType ihₓ → nothing;
           (SomeType Tₘ) ihₓ → nothing
         };
-      
+
         elab-check-mu' = λ T → nothing;
         elab-synth-mu' = case oT of λ {
           NoType → nothing;
@@ -91,7 +91,7 @@ mendler-simple-encoding =
           NoType ihₓ → nothing;
           (SomeType Tₘ) ihₓ → nothing
         };
-      
+
         elab-check-mu' = λ T → nothing;
         elab-synth-mu' = case oT of λ {
           NoType → nothing;
@@ -529,7 +529,7 @@ elab-tkh Γ (Tkt T) b = elab-typeh Γ T b ≫=maybe uncurry λ T _ → just (Tkt
 elab-tkh Γ (Tkk k) b = elab-kindh Γ k b ≫=maybe λ k → just (Tkk k)
 
 elab-pure-term Γ (Var pi x) = just (mvar x)
-elab-pure-term Γ (App t NotErased t') = 
+elab-pure-term Γ (App t NotErased t') =
   elab-pure-term Γ t ≫=maybe λ t →
   elab-pure-term Γ t' ≫=maybe λ t' →
   just (App t NotErased t')
@@ -764,7 +764,7 @@ elab-all ts fm to =
           do-type-check = ff;
           inv = refl})
        (toplevel-state.is ts)}
-  
+
   get-file-imports : toplevel-state → (filename : string) → stringset → maybe stringset
   get-file-imports ts fn is =
     get-include-elt-if ts fn ≫=maybe λ ie →
@@ -799,8 +799,3 @@ elab-file : toplevel-state → (filename : string) → maybe rope
 elab-file ts fn =
   elab-file' ts empty-renamectxt empty-renamectxt empty-trie fn ≫=maybe uncurry'' λ fn' ts ρ φ →
   get-include-elt-if ts fn ≫=maybe ie-get-span-ast
-
-
-
-
-

--- a/src/general-util.agda
+++ b/src/general-util.agda
@@ -4,8 +4,8 @@ open import lib
 open import functions public
 
 get-file-contents : (filename : string) → IO (maybe string)
-get-file-contents e = 
-  doesFileExist e >>= λ b → 
+get-file-contents e =
+  doesFileExist e >>= λ b →
      if b then
       (readFiniteFile e >>= λ s → return (just s))
      else
@@ -58,7 +58,7 @@ trie-any : ∀{A : Set} → (A → 𝔹) → trie A  → 𝔹
 trie-cal-any : ∀{A : Set} → (A → 𝔹) → cal (trie A)  → 𝔹
 trie-any f (Node odata ts) = maybe-else (trie-cal-any f ts) f odata
 trie-cal-any f [] = ff
-trie-cal-any f ((c , t) :: cs) = trie-any f t || trie-cal-any f cs 
+trie-cal-any f ((c , t) :: cs) = trie-any f t || trie-cal-any f cs
 
 trie-all : ∀{A : Set} → (A → 𝔹) → trie A → 𝔹
 trie-all f = ~_ ∘ trie-any (~_ ∘ f)
@@ -425,4 +425,3 @@ bindM' a b = bindM a (λ a → b)
 
 _≫monad_ : ∀{F : Set → Set}{{m : monad F}}{A B : Set} → F A → F B → F B
 _≫monad_ = bindM'
-

--- a/src/is-free.agda
+++ b/src/is-free.agda
@@ -21,7 +21,7 @@ are-free-in-optClass : are-free-in-t optClass
 -- are-free-in-optType : are-free-in-t optType
 are-free-in-optTerm : are-free-in-t optTerm
 are-free-in-optGuide : are-free-in-t optGuide
-are-free-in-tk : are-free-in-t tk 
+are-free-in-tk : are-free-in-t tk
 are-free-in-liftingType : are-free-in-t liftingType
 are-free-in-optType : are-free-in-t optType
 are-free-in-args : are-free-in-t args
@@ -133,26 +133,26 @@ are-free-in-liftingType ce x (LiftTpArrow t l) = are-free-in-type ce x t || are-
 are-free-in : {ed : exprd} → are-free-e → stringset → ⟦ ed ⟧ → 𝔹
 are-free-in{TERM} e x t = are-free-in-term e x t
 are-free-in{ARG} e x (TermArg _ t) = are-free-in-term e x t
-are-free-in{TYPE} e x t = are-free-in-type e x t 
+are-free-in{TYPE} e x t = are-free-in-type e x t
 are-free-in{ARG} e x (TypeArg t) = are-free-in-type e x t
 are-free-in{KIND} e x t = are-free-in-kind e x t
 are-free-in{TK} e x t = are-free-in-tk e x t
-are-free-in{LIFTINGTYPE} e x t = are-free-in-liftingType e x t 
+are-free-in{LIFTINGTYPE} e x t = are-free-in-liftingType e x t
 are-free-in{QUALIF} e x (x' , as) = trie-contains x x' || are-free-in-args e x as
 
 is-free-in : {ed : exprd} → are-free-e → var → ⟦ ed ⟧ → 𝔹
 is-free-in{TERM} e x t = are-free-in-term e (stringset-singleton x) t
 is-free-in{ARG} e x (TermArg _ t) = are-free-in-term e (stringset-singleton x) t
-is-free-in{TYPE} e x t = are-free-in-type e (stringset-singleton x) t 
+is-free-in{TYPE} e x t = are-free-in-type e (stringset-singleton x) t
 is-free-in{ARG} e x (TypeArg t) = are-free-in-type e (stringset-singleton x) t
-is-free-in{KIND} e x t = are-free-in-kind e (stringset-singleton x) t 
-is-free-in{LIFTINGTYPE} e x t = are-free-in-liftingType e (stringset-singleton x) t 
+is-free-in{KIND} e x t = are-free-in-kind e (stringset-singleton x) t
+is-free-in{LIFTINGTYPE} e x t = are-free-in-liftingType e (stringset-singleton x) t
 is-free-in{QUALIF} e x (x' , as) = x =string x' || are-free-in-args e (stringset-singleton x) as
 is-free-in{TK} e x t = are-free-in-tk e (stringset-singleton x) t
 
 abs-tk : maybeErased → var → tk → type → type
 abs-tk me x (Tkk k) tp = Abs posinfo-gen Erased posinfo-gen x (Tkk k) tp
-abs-tk me x (Tkt tp') tp with are-free-in check-erased (stringset-singleton x) tp 
+abs-tk me x (Tkt tp') tp with are-free-in check-erased (stringset-singleton x) tp
 abs-tk me x (Tkt tp') tp | tt = Abs posinfo-gen me posinfo-gen x (Tkt tp') tp
 abs-tk me x (Tkt tp') tp | ff = TpArrow tp' me tp
 
@@ -163,7 +163,7 @@ absk-tk x (Tkt tp) k | ff = KndTpArrow tp k
 absk-tk x (Tkk k') k | ff = KndArrow k' k
 
 data abs  : Set where
-  mk-abs : maybeErased → var → tk → (var-free-in-body : 𝔹) → type → abs 
+  mk-abs : maybeErased → var → tk → (var-free-in-body : 𝔹) → type → abs
 
 to-abs : type → maybe abs
 to-abs (Abs _ me _ x atk tp) = just (mk-abs me x atk (are-free-in check-erased (stringset-singleton x) tp) tp)
@@ -195,7 +195,7 @@ to-is-tpabs tp with to-abs tp
   yes-tpabs e? x k tp'
 
 data absk  : Set where
-  mk-absk : var → tk → (var-free-in-body : 𝔹) → kind → absk 
+  mk-absk : var → tk → (var-free-in-body : 𝔹) → kind → absk
 
 to-absk : kind → maybe absk
 to-absk (KndPi _ _ x atk k) = just (mk-absk x atk (are-free-in check-erased (stringset-singleton x) k) k)

--- a/src/main.agda
+++ b/src/main.agda
@@ -2,7 +2,7 @@ module main where
 
 open import lib
 import string-format
--- for parser for Cedille 
+-- for parser for Cedille
 open import cedille-types
 
 -- for parser for options files
@@ -64,7 +64,7 @@ processOptions filename s with options-types.scanOptions s
   opts-to-options filename oo
   >>= λ opts → if cedille-options.options.make-rkt-files opts
     then return ∘ inj₁ $ "Racket compilation disabled, please set to false in " ^ filename ^ "."
-  else (return ∘ inj₂ $ opts) 
+  else (return ∘ inj₂ $ opts)
 
 
 getOptionsFile : (filepath : string) → string
@@ -130,7 +130,7 @@ module main-with-options
   import interactive-cmds
   open import rkt options
   open import elaboration options
-  
+
 
   logFilepath : IO filepath
   logFilepath = getHomeDirectory >>=r λ home →
@@ -171,7 +171,7 @@ module main-with-options
   rkt-suffix = ".rkt"
 
   ced-aux-filename : (suffix ced-path : filepath) → filepath
-  ced-aux-filename sfx ced-path = 
+  ced-aux-filename sfx ced-path =
     let dir = takeDirectory ced-path in
       combineFileNames (dot-cedille-directory dir) (fileBaseName ced-path ^ sfx)
 
@@ -224,7 +224,7 @@ module main-with-options
     h ('.' :: cs) = pathSeparator :: h cs
     h (c :: cs) = c :: h cs
     h [] = []
-  
+
   find-imported-file : (dirs : 𝕃 filepath) → (unit-name : string) → IO (maybe filepath)
   find-imported-file [] unit-name = return nothing
   find-imported-file (dir :: dirs) unit-name =
@@ -255,8 +255,8 @@ module main-with-options
     where processText : string → IO include-elt
           processText x with parseStart x
           processText x | Left (Left cs)  = return (error-span-include-elt ("Error in file " ^ filename ^ ".") "Lexical error." cs)
-          processText x | Left (Right cs) = return (error-span-include-elt ("Error in file " ^ filename ^ ".") "Parsing error." cs)        
-          processText x | Right t  with cws-types.scanComments x 
+          processText x | Left (Right cs) = return (error-span-include-elt ("Error in file " ^ filename ^ ".") "Parsing error." cs)
+          processText x | Right t  with cws-types.scanComments x
           processText x | Right t | t2 = find-imported-files (fst (cedille-options.include-path-insert (takeDirectory filename) (toplevel-state.include-path st)))
                                                              (get-imports t) >>= λ deps →
                                          logMsg ("deps for file " ^ filename ^ ": " ^ 𝕃-to-string (λ {(a , b) → "short: " ^ a ^ ", long: " ^ b}) ", " deps) >>r
@@ -269,7 +269,7 @@ module main-with-options
       (set-cede-file-up-to-date-include-elt
         (set-do-type-check-include-elt
           (get-include-elt s filename) tt) ff)
-  
+
   infixl 1 _&&>>_
   _&&>>_ : IO 𝔹 → IO 𝔹 → IO 𝔹
   (a &&>> b) = a >>= λ a → if a then b else return ff
@@ -295,14 +295,14 @@ module main-with-options
       tt → doesFileExist cede &&>> doesFileExist cede' >>= λ where
         ff → return ff
         tt → fileIsOlder cede cede' >>=r λ fio → dtc || fio
-   
+
   any-imports-changed : toplevel-state → filepath → (imports : 𝕃 string) → IO 𝔹
   any-imports-changed s filename [] = return ff
   any-imports-changed s filename (h :: t) =
     import-changed s filename h >>= λ where
       tt → return tt
       ff → any-imports-changed s filename t
-  
+
   file-after-compile : filepath → IO 𝔹
   file-after-compile fn =
     getModificationTime fn >>= λ mt →
@@ -337,18 +337,18 @@ module main-with-options
   {-# TERMINATING #-}
   update-astsh : stringset {- seen already -} → toplevel-state → filepath →
                  IO (stringset {- seen already -} × toplevel-state)
-  update-astsh seen s filename = 
+  update-astsh seen s filename =
     if stringset-contains seen filename then return (seen , s)
     else (ensure-ast-depsh filename s >>= aux-up-to-date filename >>= cont (stringset-insert seen filename))
     where cont : stringset → toplevel-state → IO (stringset × toplevel-state)
           cont seen s with get-include-elt s filename
           cont seen s | ie with include-elt.deps ie
-          cont seen s | ie | ds = 
+          cont seen s | ie | ds =
             proc seen s ds
             where proc : stringset → toplevel-state → 𝕃 string → IO (stringset × toplevel-state)
                   proc seen s [] = any-imports-changed s filename ds >>=r λ changed →
                     seen , set-include-elt s filename (set-do-type-check-include-elt ie (include-elt.do-type-check ie || changed))
-                  proc seen s (d :: ds) = update-astsh seen s d >>= λ p → 
+                  proc seen s (d :: ds) = update-astsh seen s d >>= λ p →
                                           proc (fst p) (snd p) ds
 
   {- this function updates the ast associated with the given filename in the toplevel state.
@@ -366,7 +366,7 @@ module main-with-options
 
   {- this function checks the given file (if necessary), updates .cede and .rkt files (again, if necessary), and replies on stdout if appropriate -}
   checkFile : toplevel-state → filepath → (should-print-spans : 𝔹) → IO toplevel-state
-  checkFile s filename should-print-spans = 
+  checkFile s filename should-print-spans =
     update-asts s filename >>= λ s →
     log-files-to-check s >>
     logMsg (𝕃-to-string (λ {(im , fn) → "im: " ^ im ^ ", fn: " ^ fn}) "; " (trie-mappings (include-elt.import-to-dep (get-include-elt s filename)))) >>
@@ -403,8 +403,8 @@ module main-with-options
   readCommandsFromFrontend s =
       getLine >>= λ input →
       logMsg ("Frontend input: " ^ input) >>
-      let input-list : 𝕃 string 
-          input-list = (string-split (undo-escape-string input) delimiter) 
+      let input-list : 𝕃 string
+          input-list = (string-split (undo-escape-string input) delimiter)
               in (handleCommands input-list s) >>= λ s →
           readCommandsFromFrontend s
           where
@@ -458,11 +458,11 @@ module main-with-options
 
 
   -- function to process command-line arguments
-  processArgs : 𝕃 string → IO ⊤ 
+  processArgs : 𝕃 string → IO ⊤
 
   -- this is the case for when we are called with a single command-line argument, the name of the file to process
   processArgs (input-filename :: []) =
-    canonicalizePath input-filename >>= λ input-filename → 
+    canonicalizePath input-filename >>= λ input-filename →
     checkFile (new-toplevel-state (cedille-options.include-path-insert (takeDirectory input-filename) (cedille-options.options.include-path options)))
       input-filename ff {- should-print-spans -} >>= finish input-filename
     where finish : string → toplevel-state → IO ⊤
@@ -476,7 +476,7 @@ module main-with-options
   -- all other cases are errors
   processArgs xs = putStrLn ("Run with the name of one file to process, or run with no command-line arguments and enter the\n"
                            ^ "names of files one at a time followed by newlines (this is for the emacs mode).")
-  
+
   main' : 𝕃 string → IO ⊤
   main' args =
     maybeClearLogFile >>

--- a/src/meta-vars.agda
+++ b/src/meta-vars.agda
@@ -657,4 +657,3 @@ meta-vars-unfold-tmapp Γ sl Xs tp
 ... | Ys , TpArrow dom e? cod =
   Ys , yes-tmabs e? "_" dom ff cod
 ... | Ys , tp' = Ys , not-tmabs tp'
-

--- a/src/options-main.agda
+++ b/src/options-main.agda
@@ -22,7 +22,7 @@ putStrRunIf : 𝔹 → Run → IO ⊤
 putStrRunIf tt r = putStr (Run-to-string r) >> putStr "\n"
 putStrRunIf ff r = return triv
 
-processArgs : (showRun : 𝔹) → (showParsed : 𝔹) → 𝕃 string → IO ⊤ 
+processArgs : (showRun : 𝔹) → (showParsed : 𝔹) → 𝕃 string → IO ⊤
 processArgs showRun showParsed (input-filename :: []) = (readFiniteFile input-filename) >>= processText
   where processText : string → IO ⊤
         processText x with runRtn (string-to-𝕃char x)
@@ -31,12 +31,11 @@ processArgs showRun showParsed (input-filename :: []) = (readFiniteFile input-fi
         processText x | s | inj₂ r with putStrRunIf showRun r | rewriteRun r
         processText x | s | inj₂ r | sr | r' with putStrRunIf showParsed r'
         processText x | s | inj₂ r | sr | r' | sr' = sr >> sr' >> putStr (process r')
-                                     
-processArgs showRun showParsed ("--showRun" :: xs) = processArgs tt showParsed xs 
-processArgs showRun showParsed ("--showParsed" :: xs) = processArgs showRun tt xs 
+
+processArgs showRun showParsed ("--showRun" :: xs) = processArgs tt showParsed xs
+processArgs showRun showParsed ("--showParsed" :: xs) = processArgs showRun tt xs
 processArgs showRun showParsed (x :: xs) = putStr ("Unknown option " ^ x ^ "\n")
 processArgs showRun showParsed [] = putStr "Please run with the name of a file to process.\n"
 
 main : IO ⊤
 main = getArgs >>= processArgs ff ff
-

--- a/src/options-types.agda
+++ b/src/options-types.agda
@@ -47,17 +47,17 @@ path-star-1 = string
 {-# FOREIGN GHC import qualified CedilleOptionsParser #-}
 {-# FOREIGN GHC import qualified CedilleOptionsLexer #-}
 
-data str-bool : Set where 
+data str-bool : Set where
     StrBoolFalse : str-bool
     StrBoolTrue : str-bool
 {-# COMPILE GHC str-bool = data CedilleOptionsLexer.StrBool (CedilleOptionsLexer.StrBoolFalse | CedilleOptionsLexer.StrBoolTrue) #-}
 
-data paths : Set where 
+data paths : Set where
     PathsCons : path → paths → paths
     PathsNil : paths
 {-# COMPILE GHC paths = data CedilleOptionsLexer.Paths (CedilleOptionsLexer.PathsCons | CedilleOptionsLexer.PathsNil) #-}
 
-data opt : Set where 
+data opt : Set where
     GenerateLogs : str-bool → opt
     Lib : paths → opt
     MakeRktFiles : str-bool → opt
@@ -66,12 +66,12 @@ data opt : Set where
     EraseTypes : str-bool → opt
 {-# COMPILE GHC opt = data CedilleOptionsLexer.Opt (CedilleOptionsLexer.GenerateLogs | CedilleOptionsLexer.Lib | CedilleOptionsLexer.MakeRktFiles | CedilleOptionsLexer.ShowQualifiedVars | CedilleOptionsLexer.UseCedeFiles | CedilleOptionsLexer.EraseTypes) #-}
 
-data opts : Set where 
+data opts : Set where
     OptsCons : opt → opts → opts
     OptsNil : opts
-{-# COMPILE GHC opts = data CedilleOptionsLexer.Opts (CedilleOptionsLexer.OptsCons | CedilleOptionsLexer.OptsNil) #-}    
+{-# COMPILE GHC opts = data CedilleOptionsLexer.Opts (CedilleOptionsLexer.OptsCons | CedilleOptionsLexer.OptsNil) #-}
 
-data start : Set where 
+data start : Set where
     File : opts → start
 {-# COMPILE GHC start = data CedilleOptionsLexer.Start (CedilleOptionsLexer.File) #-}
 
@@ -331,4 +331,3 @@ isParseTree p l s = ⊤ {- this will be ignored since we are using simply typed 
 
 ptr : ParseTreeRec
 ptr = record { ParseTreeT = ParseTreeT ; isParseTree = isParseTree ; ParseTreeToString = ParseTreeToString }
-

--- a/src/process-cmd.agda
+++ b/src/process-cmd.agda
@@ -23,13 +23,13 @@ open import toplevel-state options {mF}
 import cws-types
 import cws
 
--- generate spans from the given comments-and-whitespace syntax tree 
+-- generate spans from the given comments-and-whitespace syntax tree
 process-cwst-etys : cws-types.entities → spanM ⊤
 process-cwst-ety : cws-types.entity → spanM ⊤
 process-cwst-etys (cws-types.Entity ety etys) = (process-cwst-ety ety) ≫span process-cwst-etys etys
 process-cwst-etys cws-types.EndEntity = spanMr triv
 process-cwst-ety cws-types.EntityNonws = spanMr triv
-process-cwst-ety (cws-types.EntityWs pi pi') = spanMr triv -- spanM-add (whitespace-span pi pi') 
+process-cwst-ety (cws-types.EntityWs pi pi') = spanMr triv -- spanM-add (whitespace-span pi pi')
 process-cwst-ety (cws-types.EntityComment pi pi') = spanM-add (comment-span pi pi')
 
 process-cwst : toplevel-state → filepath → spanM toplevel-state
@@ -72,13 +72,13 @@ process-cmds : process-t cmds
 process-params : process-t (posinfo × params)
 process-start : toplevel-state → filepath → (progress-name : string) → start → (need-to-check : 𝔹) → spanM toplevel-state
 process-file : toplevel-state → filepath → (progress-name : string) → mF (toplevel-state × mod-info)
- 
-process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefTerm pi x (SomeType tp) t) pi') tt {- check -} = 
+
+process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefTerm pi x (SomeType tp) t) pi') tt {- check -} =
   set-ctxt Γ ≫span
   check-type tp (just star) ≫span
   let tp' = qualif-type Γ tp in
-  check-term t (just tp') ≫span 
-  check-erased-margs t (just tp') ≫span 
+  check-term t (just tp') ≫span
+  check-erased-margs t (just tp') ≫span
   get-ctxt (λ Γ →
     let Γ' = ctxt-term-def pi globalScope op x t tp' Γ in
       spanM-add (DefTerm-span Γ' pi x checking (just tp) t pi' []) ≫span
@@ -92,11 +92,11 @@ process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefTerm pi x (So
       (spanMr (mk-toplevel-state ip fns is (ctxt-term-def pi globalScope op x t tp' Γ)))
 
 
-process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefTerm pi x NoType t) pi') _ = 
+process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefTerm pi x NoType t) pi') _ =
   set-ctxt Γ ≫span
-  check-term t nothing ≫=span λ mtp → 
-  check-erased-margs t nothing ≫span 
-  get-ctxt (λ Γ → 
+  check-term t nothing ≫=span λ mtp →
+  check-erased-margs t nothing ≫span
+  get-ctxt (λ Γ →
       let Γ' = maybe-else
                  (ctxt-term-udef pi globalScope op x t Γ)
                  (λ tp → ctxt-term-def pi globalScope op x t tp Γ) mtp in
@@ -107,10 +107,10 @@ process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefTerm pi x NoT
 
 process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefType pi x k tp) pi') tt {- check -} =
     set-ctxt Γ ≫span
-    check-kind k ≫span 
+    check-kind k ≫span
     let k' = qualif-kind Γ k in
-    check-type tp (just k') ≫span 
-    get-ctxt (λ Γ → 
+    check-type tp (just k') ≫span
+    get-ctxt (λ Γ →
       let Γ' = ctxt-type-def pi globalScope op x tp k' Γ in
         spanM-add (DefType-span Γ' pi x checking (just k) tp pi' []) ≫span
         check-redefined pi x (mk-toplevel-state ip fns is Γ)
@@ -118,16 +118,16 @@ process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefType pi x k t
            spanMr (mk-toplevel-state ip fns is Γ')))
 
 
-process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefType pi x k tp) pi') ff {- skip checking -} = 
+process-cmd (mk-toplevel-state ip fns is Γ) (DefTermOrType op (DefType pi x k tp) pi') ff {- skip checking -} =
   let k' = qualif-kind Γ k in
     check-redefined pi x (mk-toplevel-state ip fns is Γ)
       (spanMr (mk-toplevel-state ip fns is (ctxt-type-def pi globalScope op x tp k' Γ)))
 
 process-cmd (mk-toplevel-state ip fns is Γ) (DefKind pi x ps k pi') tt {- check -} =
   set-ctxt Γ ≫span
-  check-and-add-params pi' ps ≫=span λ ms → 
+  check-and-add-params pi' ps ≫=span λ ms →
   check-kind k ≫span
-  get-ctxt (λ Γ → 
+  get-ctxt (λ Γ →
     let Γ' = ctxt-kind-def pi x ps k Γ in
       spanM-add (DefKind-span Γ' pi x k pi') ≫span
       check-redefined pi x (mk-toplevel-state ip fns is Γ)
@@ -135,10 +135,10 @@ process-cmd (mk-toplevel-state ip fns is Γ) (DefKind pi x ps k pi') tt {- check
         spanMr (mk-toplevel-state ip fns is (ctxt-restore-info* Γ' ms))))
 
 
-process-cmd (mk-toplevel-state ip fns is Γ) (DefKind pi x ps k pi') ff {- skip checking -} = 
+process-cmd (mk-toplevel-state ip fns is Γ) (DefKind pi x ps k pi') ff {- skip checking -} =
   set-ctxt Γ ≫span
-  dont-check-and-add-params pi' ps ≫=span λ ms → 
-  get-ctxt (λ Γ → 
+  dont-check-and-add-params pi' ps ≫=span λ ms →
+  get-ctxt (λ Γ →
     let Γ' = ctxt-kind-def pi x ps k Γ in
       check-redefined pi x (mk-toplevel-state ip fns is Γ)
         (spanMr (mk-toplevel-state ip fns is (ctxt-restore-info* Γ' ms))))
@@ -185,7 +185,7 @@ process-cmd s (ImportCmd (Import pi op pi' x oa as pi'')) _ =
       if cₙ ≥ aₙ then err else h (just aₙ) as
     h n ArgsNil = nothing
 
-  
+
   process-import : optPublic → optAs → (cur imp : filepath) → maybe params → params → spanM err-m
   process-import op oa fnₒ fnᵢ nothing _ = spanMr (just "Undefined module import (this probably shouldn't happen?)")
   -- process-import op oa fnₒ fnᵢ (just psᵢ) nothing = spanMr (just "Current module undefined (this shouldn't happen!)")
@@ -199,8 +199,8 @@ process-cmd s (ImportCmd (Import pi op pi' x oa as pi'')) _ =
 
 process-cmd (mk-toplevel-state ip fns is Γ) (DefDatatype dd@(Datatype pi pix x ps k cs _) pi') _  =
     set-ctxt Γ ≫span
-    check-kind (add-params-kind ps k) ≫span -- 
-    get-ctxt (λ Γ → 
+    check-kind (add-params-kind ps k) ≫span --
+    get-ctxt (λ Γ →
       let Γ' = ctxt-datatype-def pi x (qualif-params Γ ps) (qualif-kind Γ (add-params-kind ps k)) (Datatype pi pix x ps k cs pi') Γ in
         set-ctxt Γ'                                          ≫span
         spanM-add (DefDatatype-span pi pix x pi')            ≫span
@@ -220,14 +220,14 @@ process-params s (pi , ps) need-to-check =
   set-ctxt (toplevel-state.Γ s) ≫span
   check-and-add-params pi ps ≫=span λ _ →
   spanM-set-params ps ≫span
-  get-ctxt λ Γ → 
+  get-ctxt λ Γ →
   spanMr (record s {Γ = ctxt-add-current-params Γ})
 
 process-start s filename pn (File pi0 is pi1 pi2 mn ps cs pi3) need-to-check =
   λ Γ ss → progress-update pn need-to-check ≫monad
   (process-cmds s (imps-to-cmds is) need-to-check ≫=span λ s →
    process-params s (pi0 , ps) need-to-check ≫=span λ s →
-   process-cmds s cs need-to-check ≫=span λ s → 
+   process-cmds s cs need-to-check ≫=span λ s →
    process-cwst s filename ≫=span λ s →
      spanM-add (File-span (toplevel-state.Γ s) pi0 (posinfo-plus pi3 1) filename) ≫span
      let pi2' = posinfo-plus-str pi2 mn in
@@ -235,7 +235,7 @@ process-start s filename pn (File pi0 is pi1 pi2 mn ps cs pi3) need-to-check =
      spanM-add (Module-header-span pi1 pi2') ≫span
      spanMr s) Γ ss
 
-{- process (type-check if necessary) the given file.  
+{- process (type-check if necessary) the given file.
    We assume the given top-level state has a syntax tree associated with the file. -}
 process-file s filename pn with get-include-elt s filename
 process-file s filename pn | ie =
@@ -247,7 +247,7 @@ process-file s filename pn | ie =
         proceed s nothing ie' = progress-update filename tt ≫monad returnM (s , ie' , ctxt-get-current-mod (toplevel-state.Γ s)) {- should not happen -}
         proceed s (just x) ie' with include-elt.need-to-add-symbols-to-context ie {- this indeed should be ie, not ie' -}
         proceed (mk-toplevel-state ip fns is Γ) (just x) ie' | tt
-          with include-elt.do-type-check ie | ctxt-get-current-mod Γ 
+          with include-elt.do-type-check ie | ctxt-get-current-mod Γ
         proceed (mk-toplevel-state ip fns is Γ) (just x) ie' | tt | do-check | prev-mod =
          let Γ = ctxt-initiate-file Γ filename (start-modname x) in
            process-start (mk-toplevel-state ip fns (trie-insert is filename ie') Γ)
@@ -262,12 +262,9 @@ process-file s filename pn | ie =
 
 process-consts DataNull ps = spanMok
 process-consts (DataCons (DataConst pi c tp) cs) ps =
-      get-ctxt (λ Γ → 
+      get-ctxt (λ Γ →
         let t = abs-expand-type' ps tp in -- add-param-type ps (qualif-type Γ tp)
-        check-type t (just star) ≫span 
+        check-type t (just star) ≫span
         set-ctxt (ctxt-const-def pi c (qualif-type Γ t) Γ) ≫span
         spanM-add (DefDataConst-span pi c)  ≫span
         process-consts cs ps)
-
-
-

--- a/src/rename.agda
+++ b/src/rename.agda
@@ -2,13 +2,13 @@ module rename where
 
 open import lib
 
-open import cedille-types 
+open import cedille-types
 open import ctxt-types
 open import is-free
 open import syntax-util
 
 renamectxt : Set
-renamectxt = stringset × trie string  {- the trie maps vars to their renamed versions, 
+renamectxt = stringset × trie string  {- the trie maps vars to their renamed versions,
                                          and the stringset stores all those renamed versions -}
 
 empty-renamectxt : renamectxt
@@ -64,8 +64,8 @@ fresh-var : string → (string → 𝔹) → renamectxt → string
 fresh-var = rename-away-from
 
 rename-var-if : {ed : exprd} → ctxt → renamectxt → var → ⟦ ed ⟧ → var
-rename-var-if Γ ρ y t = 
-  if is-free-in check-erased y t || renamectxt-in-range ρ y then 
+rename-var-if Γ ρ y t =
+  if is-free-in check-erased y t || renamectxt-in-range ρ y then
     rename-away-from y (ctxt-binds-var Γ) ρ
   else
     y

--- a/src/rewriting.agda
+++ b/src/rewriting.agda
@@ -13,14 +13,14 @@ open import subst
 open import syntax-util
 
 private
-  
+
   mk-phi : var → (eq t t' : term) → term
   mk-phi x eq t t' =
     Phi posinfo-gen
       (Rho posinfo-gen RhoPlain NoNums eq
         (Guide posinfo-gen x (TpEq posinfo-gen t t' posinfo-gen))
         (Beta posinfo-gen (SomeTerm t posinfo-gen) (SomeTerm id-term posinfo-gen)))
-      t t' posinfo-gen 
+      t t' posinfo-gen
 
   head-types-match : ctxt → trie term → (complete partial : type) → 𝔹
   head-types-match Γ σ (TpApp T _) (TpApp T' _) = conv-type Γ T (substs Γ σ T')
@@ -95,7 +95,7 @@ rewrite-type T Γ tt on eq t₁ t₂ sn
 rewrite-type = rewrite-typeh
 
 rewrite-typeh (Abs pi b pi' x atk T) =
-  rewrite-rename-var x λ x' → 
+  rewrite-rename-var x λ x' →
   rewriteR (Abs pi b pi' x') ≫rewrite rewrite-tk atk ≫rewrite
   rewrite-abs x x' rewrite-type T
 rewrite-typeh (Iota pi pi' x T T') =

--- a/src/rkt.agda
+++ b/src/rkt.agda
@@ -26,12 +26,12 @@ private
   rkt-dbg msg out = [[ if rkt-dbg-flag then ("; " ^ msg ^ "\n") else "" ]] ⊹⊹ out
 
 -- constructs the name of a .racket directory for the given original directory
-rkt-dirname : string → string 
+rkt-dirname : string → string
 rkt-dirname dir = combineFileNames dir ".racket"
 
 -- constructs the fully-qualified name of a .rkt file for a .ced file at the given ced-path
 {-rkt-filename : (ced-path : string) → string
-rkt-filename ced-path = 
+rkt-filename ced-path =
   let dir = takeDirectory ced-path in
   let unit-name = base-filename (takeFileName ced-path) in
     combineFileNames (rkt-dirname dir) (unit-name ^ ".rkt")-}
@@ -95,9 +95,9 @@ rkt-from-sym-info n (rename-def v , _)
   = rkt-dbg ("rename-def: " ^ v)    [[]]
 rkt-from-sym-info n (var-decl , _)
   = rkt-dbg "var-decl:"             [[]]
-rkt-from-sym-info n (const-def _ , _) 
+rkt-from-sym-info n (const-def _ , _)
   = rkt-dbg "const-def:"           [[]]
-rkt-from-sym-info n (datatype-def _ _ , _) 
+rkt-from-sym-info n (datatype-def _ _ , _)
   = rkt-dbg "datatype-def:"           [[]]
 
 to-rkt-file : (ced-path : string) → ctxt → include-elt → ((cede-filename : string) → string) → rope

--- a/src/spans.agda
+++ b/src/spans.agda
@@ -6,7 +6,7 @@ open import lib
 open import functions
 
 open import cedille-types
-open import constants 
+open import constants
 open import conversion
 open import ctxt
 open import is-free
@@ -26,9 +26,9 @@ data span : Set where
   mk-span : string → posinfo → posinfo → 𝕃 tagged-val {- extra information for the span -} → err-m → span
 
 span-to-rope : span → rope
-span-to-rope (mk-span name start end extra nothing) = 
+span-to-rope (mk-span name start end extra nothing) =
   [[ "[\"" ^ name ^ "\"," ^ start ^ "," ^ end ^ ",{" ]] ⊹⊹ tagged-vals-to-rope 0 extra ⊹⊹ [[ "}]" ]]
-span-to-rope (mk-span name start end extra (just err)) = 
+span-to-rope (mk-span name start end extra (just err)) =
   [[ "[\"" ^ name ^ "\"," ^ start ^ "," ^ end ^ ",{" ]] ⊹⊹ tagged-vals-to-rope 0 (("error" , [[ err ]] , []) :: extra) ⊹⊹ [[ "}]" ]]
 
 data error-span : Set where
@@ -124,7 +124,7 @@ spanM-push-term-def pi x t T Γ ss = let qi = ctxt-get-qi Γ x in returnM ((qi ,
 
 spanM-push-term-udef : posinfo → var → term → spanM restore-def
 spanM-push-term-udef pi x t Γ ss = let qi = ctxt-get-qi Γ x in returnM ((qi , qi ≫=maybe λ qi → ctxt-get-info (fst qi) Γ) , ctxt-term-udef pi localScope OpacTrans x t Γ , ss)
- 
+
  -- return previous ctxt-info, if any
 spanM-push-type-decl : posinfo → var → kind → spanM restore-def
 spanM-push-type-decl pi x k Γ ss = let qi = ctxt-get-qi Γ x in returnM ((qi , qi ≫=maybe λ qi → ctxt-get-info (fst qi) Γ) , ctxt-type-decl pi x k Γ , ss)
@@ -509,7 +509,7 @@ parens-span pi pi' = mk-span "parentheses" pi pi' [] nothing
 
 data decl-class : Set where
   param : decl-class
-  index : decl-class 
+  index : decl-class
 
 decl-class-name : decl-class → string
 decl-class-name param = "parameter"
@@ -523,7 +523,7 @@ TpVar-span : ctxt → posinfo → string → checking-mode → 𝕃 tagged-val �
 TpVar-span Γ pi v check tvs = mk-span "Type variable" pi (posinfo-plus-str pi (unqual-local v)) (checking-data check :: ll-data-type :: var-location-data Γ v :: symbol-data (unqual-local v) :: tvs)
 
 Var-span : ctxt → posinfo → string → checking-mode → 𝕃 tagged-val → err-m → span
-Var-span Γ pi v check tvs = mk-span "Term variable" pi (posinfo-plus-str pi (unqual-local v)) (checking-data check :: ll-data-term :: var-location-data Γ v :: symbol-data (unqual-local v) :: tvs) 
+Var-span Γ pi v check tvs = mk-span "Term variable" pi (posinfo-plus-str pi (unqual-local v)) (checking-data check :: ll-data-term :: var-location-data Γ v :: symbol-data (unqual-local v) :: tvs)
 
 KndVar-span : ctxt → (posinfo × var) → (end-pi : posinfo) → params → checking-mode → 𝕃 tagged-val → err-m → span
 KndVar-span Γ (pi , v) pi' ps check tvs =
@@ -617,7 +617,7 @@ Lam-span : ctxt → checking-mode → posinfo → maybeErased → var → optCla
 Lam-span Γ c pi NotErased x (SomeClass (Tkk k)) t tvs e =
   mk-span (Lam-span-erased NotErased) pi (term-end-pos t) (ll-data-term :: binder-data-const :: checking-data c :: tvs) (e maybe-or just "λ-terms must bind a term, not a type (use Λ instead)")
 Lam-span _ c pi l x NoClass t tvs = mk-span (Lam-span-erased l) pi (term-end-pos t) (ll-data-term :: binder-data-const :: checking-data c :: tvs)
-Lam-span Γ c pi l x (SomeClass atk) t tvs = mk-span (Lam-span-erased l) pi (term-end-pos t) 
+Lam-span Γ c pi l x (SomeClass atk) t tvs = mk-span (Lam-span-erased l) pi (term-end-pos t)
                                            ((ll-data-term :: binder-data-const :: checking-data c :: tvs)
                                            ++ [ to-string-tag-tk "type of bound variable" Γ atk ])
 
@@ -634,28 +634,28 @@ compileFail-in Γ t with is-free-in check-erased compileFail-qual | qualif-term 
 
 
 DefTerm-span : ctxt → posinfo → var → (checked : checking-mode) → maybe type → term → posinfo → 𝕃 tagged-val → span
-DefTerm-span Γ pi x checked tp t pi' tvs = 
+DefTerm-span Γ pi x checked tp t pi' tvs =
   h ((h-summary tp) ++ (erasure Γ t :: tvs)) pi x checked tp pi'
   where h : 𝕃 tagged-val → posinfo → var → (checked : checking-mode) → maybe type → posinfo → span
-        h tvs pi x checking _ pi' = 
+        h tvs pi x checking _ pi' =
           mk-span "Term-level definition (checking)" pi pi' tvs nothing
-        h tvs pi x _ (just tp) pi' = 
+        h tvs pi x _ (just tp) pi' =
           mk-span "Term-level definition (synthesizing)" pi pi' (to-string-tag "synthesized type" Γ tp :: tvs) nothing
-        h tvs pi x _ nothing pi' = 
+        h tvs pi x _ nothing pi' =
           mk-span "Term-level definition (synthesizing)" pi pi' (("synthesized type" , [[ "[nothing]" ]] , []) :: tvs) nothing
         h-summary : maybe type → 𝕃 tagged-val
         h-summary nothing = [(checking-data synthesizing)]
         h-summary (just tp) = (checking-data checking :: [ summary-data x Γ tp ])
-    
+
 CheckTerm-span : ctxt → (checked : checking-mode) → maybe type → term → posinfo → 𝕃 tagged-val → span
-CheckTerm-span Γ checked tp t pi' tvs = 
+CheckTerm-span Γ checked tp t pi' tvs =
   h (erasure Γ t :: tvs) checked tp (term-start-pos t) pi'
   where h : 𝕃 tagged-val → (checked : checking-mode) → maybe type → posinfo → posinfo → span
-        h tvs checking _ pi pi' = 
+        h tvs checking _ pi pi' =
           mk-span "Checking a term" pi pi' (checking-data checking :: tvs) nothing
-        h tvs _ (just tp) pi pi' = 
+        h tvs _ (just tp) pi pi' =
           mk-span "Synthesizing a type for a term" pi pi' (checking-data synthesizing :: to-string-tag "synthesized type" Γ tp :: tvs) nothing
-        h tvs _ nothing pi pi' = 
+        h tvs _ nothing pi pi' =
           mk-span "Synthesizing a type for a term" pi pi' (checking-data synthesizing :: ("synthesized type" , [[ "[nothing]" ]] , []) :: tvs) nothing
 
 normalized-type : ctxt → type → tagged-val
@@ -686,14 +686,14 @@ Beta-span pi pi' check tvs = mk-span "Beta axiom" pi pi'
                      (checking-data check :: ll-data-term :: explain "A term constant whose type states that β-equal terms are provably equal" :: tvs)
 
 hole-span : ctxt → posinfo → maybe type → 𝕃 tagged-val → span
-hole-span Γ pi tp tvs = 
+hole-span Γ pi tp tvs =
   mk-span "Hole" pi (posinfo-plus pi 1)
     (ll-data-term :: expected-type-if Γ tp ++ tvs)
     (just "This hole remains to be filled in")
 
 tp-hole-span : ctxt → posinfo → maybe kind → 𝕃 tagged-val → span
 tp-hole-span Γ pi k tvs =
-  mk-span "Hole" pi (posinfo-plus pi 1) 
+  mk-span "Hole" pi (posinfo-plus pi 1)
     (ll-data-term :: expected-kind-if Γ k ++ tvs)
     (just "This hole remains to be filled in")
 
@@ -704,10 +704,10 @@ expected-to-string synthesizing = "synthesized"
 expected-to-string untyped = "untyped"
 
 Epsilon-span : posinfo → leftRight → maybeMinus → term → checking-mode → 𝕃 tagged-val → err-m → span
-Epsilon-span pi lr m t check tvs = mk-span "Epsilon" pi (term-end-pos t) 
+Epsilon-span pi lr m t check tvs = mk-span "Epsilon" pi (term-end-pos t)
                                          (checking-data check :: ll-data-term :: tvs ++
-                                         [ explain ("Normalize " ^ side lr ^ " of the " 
-                                                   ^ expected-to-string check ^ " equation, using " ^ maybeMinus-description m 
+                                         [ explain ("Normalize " ^ side lr ^ " of the "
+                                                   ^ expected-to-string check ^ " equation, using " ^ maybeMinus-description m
                                                    ^ " reduction." ) ])
   where side : leftRight → string
         side Left = "the left-hand side"
@@ -727,9 +727,9 @@ Rho-span pi t t' expected r (inj₂ x) tvs =
   mk-span "Rho" pi (term-end-pos t')
     (checking-data expected :: ll-data-term :: explain ("Rewrite all places where " ^ x ^ " occurs in the " ^ expected-to-string expected ^ " type, using an equation. ") :: tvs)
 Rho-span pi t t' expected r (inj₁ numrewrites) tvs err =
-  mk-span "Rho" pi (term-end-pos t') 
+  mk-span "Rho" pi (term-end-pos t')
     (checking-data expected :: ll-data-term :: tvs ++
-    (explain ("Rewrite terms in the " 
+    (explain ("Rewrite terms in the "
       ^ expected-to-string expected ^ " type, using an equation. "
       ^ (if (is-rho-plus r) then "" else "Do not ") ^ "Beta-reduce the type as we look for matches.") :: fst h)) (snd h)
   where h : 𝕃 tagged-val × err-m
@@ -746,11 +746,11 @@ Chi-span : ctxt → posinfo → optType → term → checking-mode → 𝕃 tagg
 Chi-span Γ pi m t' check tvs = mk-span "Chi" pi (term-end-pos t')  (ll-data-term :: checking-data check :: tvs ++ helper m)
   where helper : optType → 𝕃 tagged-val
         helper (SomeType T) =  explain ("Check a term against an asserted type") :: [ to-string-tag "the asserted type" Γ T ]
-        helper NoType = [ explain ("Change from checking mode (outside the term) to synthesizing (inside)") ] 
+        helper NoType = [ explain ("Change from checking mode (outside the term) to synthesizing (inside)") ]
 
 Sigma-span : posinfo → term → checking-mode → 𝕃 tagged-val → err-m → span
 Sigma-span pi t check tvs =
-  mk-span "Sigma" pi (term-end-pos t) 
+  mk-span "Sigma" pi (term-end-pos t)
      (ll-data-term :: checking-data check :: explain "Swap the sides of the equation synthesized for the body of this term" :: tvs)
 
 Delta-span : ctxt → posinfo → optType → term → checking-mode → 𝕃 tagged-val → err-m → span
@@ -774,7 +774,7 @@ Theta-span Γ pi u t ls check tvs = mk-span "Theta" pi (lterms-end-pos ls) (ll-d
   where do-explain : theta → 𝕃 tagged-val
         do-explain Abstract = [ explain ("Perform an elimination with the first term, after abstracting it from the expected type.") ]
         do-explain (AbstractVars vs) = [ strRunTag "explanation" Γ (strAdd "Perform an elimination with the first term, after abstracting the listed variables (" ≫str vars-to-string vs ≫str strAdd ") from the expected type.") ]
-        do-explain AbstractEq = [ explain ("Perform an elimination with the first term, after abstracting it with an equation " 
+        do-explain AbstractEq = [ explain ("Perform an elimination with the first term, after abstracting it with an equation "
                                          ^ "from the expected type.") ]
 
 Lft-span : posinfo → var → term → checking-mode → 𝕃 tagged-val → err-m → span
@@ -828,5 +828,3 @@ DefDatatype-span pi _ x pi' = mk-span "Datatype definition" pi pi' [] nothing
 
 DefDataConst-span : posinfo → var → span
 DefDataConst-span pi c = mk-span "Datatype constructor" pi (posinfo-plus-str pi c) [] nothing
-
-

--- a/src/subst.agda
+++ b/src/subst.agda
@@ -39,10 +39,10 @@ substh{QUALIF} = λ Γ ρ σ q → q
 subst-rename-var-if : {ed : exprd} → ctxt → renamectxt → var → trie ⟦ ed ⟧ → var
 subst-rename-var-if Γ ρ "_" σ = "_"
 subst-rename-var-if Γ ρ x σ =
-  {- rename bound variable x iff it is one of the vars being substituted for, 
-     or if x occurs free in one of the terms we are substituting for vars, 
+  {- rename bound variable x iff it is one of the vars being substituted for,
+     or if x occurs free in one of the terms we are substituting for vars,
      or if it is the renamed version of any variable -}
-  if trie-contains σ x || trie-any (is-free-in check-erased x) σ || renamectxt-in-range ρ x || ctxt-binds-var Γ x then 
+  if trie-contains σ x || trie-any (is-free-in check-erased x) σ || renamectxt-in-range ρ x || ctxt-binds-var Γ x then
     rename-away-from x (λ s → ctxt-binds-var Γ s || trie-contains σ s) ρ
   else
     x
@@ -51,7 +51,7 @@ substh-term Γ ρ σ (App t m t') = App (substh-term Γ ρ σ t) m (substh-term 
 substh-term Γ ρ σ (AppTp t tp) = AppTp (substh-term Γ ρ σ t) (substh-type Γ ρ σ tp)
 substh-term Γ ρ σ (Lam _ b _ x oc t) =
   let x' = subst-rename-var-if Γ ρ x σ in
-    Lam posinfo-gen b posinfo-gen x' (substh-optClass Γ ρ σ oc) 
+    Lam posinfo-gen b posinfo-gen x' (substh-optClass Γ ρ σ oc)
       (substh-term (ctxt-var-decl x' Γ) (renamectxt-insert ρ x x') σ t)
 substh-term Γ ρ σ (Let _ (DefTerm _ x m t) t') =
   let x' = subst-rename-var-if Γ ρ x σ in
@@ -128,7 +128,7 @@ substh-type Γ ρ σ (Abs _ b _ x atk t) =
       (substh-type (ctxt-var-decl x' Γ) (renamectxt-insert ρ x x') σ t)
 substh-type Γ ρ σ (TpLambda _ _ x atk t) =
   let x' = subst-rename-var-if Γ ρ x σ in
-    TpLambda posinfo-gen posinfo-gen x' (substh-tk Γ ρ σ atk) 
+    TpLambda posinfo-gen posinfo-gen x' (substh-tk Γ ρ σ atk)
       (substh-type (ctxt-var-decl x' Γ) (renamectxt-insert ρ x x') σ t)
 substh-type Γ ρ σ (Iota _ _ x m t) =
   let x' = subst-rename-var-if Γ ρ x σ in
@@ -136,7 +136,7 @@ substh-type Γ ρ σ (Iota _ _ x m t) =
       (substh-type (ctxt-var-decl x' Γ) (renamectxt-insert ρ x x') σ t)
 substh-type Γ ρ σ (Lft _ _ x t l) =
   let x' = subst-rename-var-if Γ ρ x σ in
-    Lft posinfo-gen posinfo-gen x' (substh-term (ctxt-var-decl x' Γ) (renamectxt-insert ρ x x') σ t) 
+    Lft posinfo-gen posinfo-gen x' (substh-term (ctxt-var-decl x' Γ) (renamectxt-insert ρ x x') σ t)
       (substh-liftingType Γ ρ σ l)
 substh-type Γ ρ σ (TpApp tp tp₁) = TpApp (substh-type Γ ρ σ tp) (substh-type Γ ρ σ tp₁)
 substh-type Γ ρ σ (TpAppt tp t) = TpAppt (substh-type Γ ρ σ tp) (substh-term Γ ρ σ t)
@@ -198,11 +198,11 @@ substh-optClass Γ ρ σ (SomeClass atk) = SomeClass (substh-tk Γ ρ σ atk)
 substh-liftingType Γ ρ σ (LiftArrow l l₁) = LiftArrow (substh-liftingType Γ ρ σ l) (substh-liftingType Γ ρ σ l₁)
 substh-liftingType Γ ρ σ (LiftParens _ l _) = substh-liftingType Γ ρ σ l
 substh-liftingType Γ ρ σ (LiftPi _ x tp l) =
-  let x' = subst-rename-var-if Γ ρ x σ in 
-    LiftPi posinfo-gen x' (substh-type Γ ρ σ tp) 
+  let x' = subst-rename-var-if Γ ρ x σ in
+    LiftPi posinfo-gen x' (substh-type Γ ρ σ tp)
        (substh-liftingType (ctxt-var-decl x' Γ) (renamectxt-insert ρ x x') σ l)
 substh-liftingType Γ ρ σ (LiftStar _) = LiftStar posinfo-gen
-substh-liftingType Γ ρ σ (LiftTpArrow tp l) = 
+substh-liftingType Γ ρ σ (LiftTpArrow tp l) =
   LiftTpArrow (substh-type Γ ρ σ tp) (substh-liftingType Γ ρ σ l)
 
 substh-optType Γ ρ σ NoType = NoType

--- a/src/syntax-util.agda
+++ b/src/syntax-util.agda
@@ -501,7 +501,7 @@ data tty : Set where
   tterm : term → tty
   ttype : type → tty
 
-decompose-tpapps : type → type × 𝕃 tty 
+decompose-tpapps : type → type × 𝕃 tty
 decompose-tpapps (TpApp t t') with decompose-tpapps t
 decompose-tpapps (TpApp t t') | h , args = h , (ttype t') :: args
 decompose-tpapps (TpAppt t t') with decompose-tpapps t

--- a/src/to-string.agda
+++ b/src/to-string.agda
@@ -218,7 +218,7 @@ params-to-string : params → strM
 params-to-string' : strM → params → strM
 file-to-string : start → strM
 cmds-to-string : cmds → strM → strM
-cmd-to-string : cmd → strM → strM  
+cmd-to-string : cmd → strM → strM
 optTerm-to-string : optTerm → string → string → strM
 optClass-to-string : optClass → strM
 optGuide-to-string : optGuide → strM
@@ -269,11 +269,11 @@ to-stringh = to-stringh' neither
 constructors-to-string DataNull                        = strEmpty
 constructors-to-string (DataCons (DataConst _ x t) ds) =
   strAdd "  | "  ≫str
-  strAdd x      ≫str 
+  strAdd x      ≫str
   strAdd " : "  ≫str
   type-to-stringh  t ≫str
   constructors-to-string ds
-  
+
 tk-to-stringh (Tkt T) = to-stringh T
 tk-to-stringh (Tkk k) = to-stringh k
 
@@ -412,7 +412,7 @@ cmds-to-string (CmdsNext c cs) f =
    cmd-to-string c
   (strAdd "\n" ≫str
    cmds-to-string cs f)
-  
+
 cmd-to-string (DefTermOrType op (DefTerm pi x mcT t) _) f =
   strM-Γ λ Γ →
   let ps = ctxt-get-current-params Γ in
@@ -456,9 +456,9 @@ cmd-to-string (ImportCmd (Import _ op _ fn oa as _)) f =
 cmd-to-string (DefDatatype (Datatype pi pix x ps k cs pi') pi'') f =
   strAdd "data " ≫str
   strAdd x ≫str
-  strAdd " " ≫str  
+  strAdd " " ≫str
   params-to-string ps ≫str
-  strAdd " : " ≫str    
+  strAdd " : " ≫str
   kind-to-stringh k ≫str
   strAdd " = " ≫str
   constructors-to-string cs ≫str
@@ -487,4 +487,3 @@ tk-to-string Γ atk = strRun Γ (tk-to-stringh atk)
 
 params-to-string-tag : string → ctxt → params → tagged-val
 params-to-string-tag name Γ ps = strRunTag name Γ (params-to-string ps)
-

--- a/src/toplevel-state.agda
+++ b/src/toplevel-state.agda
@@ -27,7 +27,7 @@ record include-elt : Set where
         import-to-dep : trie string {- map import strings in the file to their full paths -}
         ss : spans ⊎ string {- spans in string form (read from disk) -}
         err : 𝔹 -- is ss reporting an error
-        need-to-add-symbols-to-context : 𝔹 
+        need-to-add-symbols-to-context : 𝔹
         do-type-check : 𝔹
         inv : do-type-check imp need-to-add-symbols-to-context ≡ tt
         last-parse-time : maybe UTC
@@ -55,18 +55,18 @@ error-span-include-elt : string → string → posinfo → include-elt
 error-span-include-elt err errSpan pos = record blank-include-elt { ss = inj₁ (add-span (span.mk-span err pos (posinfo-plus pos 1) [] (just errSpan) ) empty-spans ) ; err = tt }
 
 set-do-type-check-include-elt : include-elt → 𝔹 → include-elt
-set-do-type-check-include-elt ie b = 
- record ie { need-to-add-symbols-to-context = (b || include-elt.need-to-add-symbols-to-context ie) ; 
-             do-type-check = b ; 
+set-do-type-check-include-elt ie b =
+ record ie { need-to-add-symbols-to-context = (b || include-elt.need-to-add-symbols-to-context ie) ;
+             do-type-check = b ;
              inv = lem b }
  where lem : (b : 𝔹) → b imp (b || include-elt.need-to-add-symbols-to-context ie) ≡ tt
        lem tt = refl
        lem ff = refl
 
 set-need-to-add-symbols-to-context-include-elt : include-elt → 𝔹 → include-elt
-set-need-to-add-symbols-to-context-include-elt ie b = 
- record ie { need-to-add-symbols-to-context = b ; 
-             do-type-check = b && include-elt.do-type-check ie ; 
+set-need-to-add-symbols-to-context-include-elt ie b =
+ record ie { need-to-add-symbols-to-context = b ;
+             do-type-check = b && include-elt.do-type-check ie ;
              inv = lem b }
  where lem : ∀(b : 𝔹){b' : 𝔹} → b && b' imp b ≡ tt
        lem tt {tt} = refl
@@ -75,8 +75,8 @@ set-need-to-add-symbols-to-context-include-elt ie b =
        lem ff {ff} = refl
 
 set-spans-include-elt : include-elt → spans → include-elt
-set-spans-include-elt ie ss = 
- record ie { ss = inj₁ ss ; 
+set-spans-include-elt ie ss =
+ record ie { ss = inj₁ ss ;
              err = spans-have-error ss  }
 
 set-last-parse-time-include-elt : include-elt → UTC → include-elt
@@ -104,7 +104,7 @@ record toplevel-state : Set where
 new-toplevel-state : (include-path : 𝕃 string × stringset) → toplevel-state
 new-toplevel-state ip = record { include-path = ip ;
                                                                              files-with-updated-spans = [] ; is = empty-trie ; Γ = new-ctxt "[nofile]" "[nomod]" }
-                                                                             
+
 toplevel-state-lookup-occurrences : var → toplevel-state → 𝕃 (var × posinfo × string)
 toplevel-state-lookup-occurrences symb (mk-toplevel-state _ _ _ Γ) = ctxt-lookup-occurrences Γ symb
 
@@ -118,10 +118,10 @@ get-include-elt s filename | nothing = blank-include-elt {- should not happen -}
 get-include-elt s filename | just ie = ie
 
 
-set-include-elt : toplevel-state → filepath → include-elt → toplevel-state 
+set-include-elt : toplevel-state → filepath → include-elt → toplevel-state
 set-include-elt s f ie = record s { is = trie-insert (toplevel-state.is s) f ie }
 
-set-include-path : toplevel-state → 𝕃 string × stringset → toplevel-state 
+set-include-path : toplevel-state → 𝕃 string × stringset → toplevel-state
 set-include-path s ip = record s { include-path = ip }
 
 get-do-type-check : toplevel-state → string → 𝔹
@@ -142,9 +142,9 @@ include-elt-to-string ie =
     " deps:  " ^ (𝕃-to-string (λ x → x) "," (include-elt.deps ie)) ^
     -- ast
     ", ast:  " ^ maybe-else "not parsed" (λ ast → "parsed") (include-elt.ast ie) ^ ", " ^
-    " import-to-dep:  " ^ (trie-to-string "," (format "filename: %s") (include-elt.import-to-dep ie)) ^ 
+    " import-to-dep:  " ^ (trie-to-string "," (format "filename: %s") (include-elt.import-to-dep ie)) ^
     -- spans
-    " err:  " ^ (𝔹-to-string (include-elt.err ie)) ^ 
+    " err:  " ^ (𝔹-to-string (include-elt.err ie)) ^
     ", need-to-add-symbols-to-context:  " ^ (𝔹-to-string (include-elt.need-to-add-symbols-to-context ie)) ^
     ", do-type-check:  " ^ (𝔹-to-string (include-elt.do-type-check ie)) ^
     ", last-parse-time: " ^ (maybe-else "" utcToString (include-elt.last-parse-time ie))
@@ -197,8 +197,8 @@ ctxt-to-string (mk-ctxt mi (ss , mn-fn) is os d) = "mod-info: {" ^ (mod-info-to-
 
 toplevel-state-to-string : toplevel-state → string
 toplevel-state-to-string (mk-toplevel-state include-path files is context) =
-    "\ninclude-path: {\n" ^ (𝕃-to-string (λ x → x) "\n" (fst include-path)) ^ 
-    "\n}\nis: {" ^ (trie-to-string "\n" include-elt-to-string is) ^ 
+    "\ninclude-path: {\n" ^ (𝕃-to-string (λ x → x) "\n" (fst include-path)) ^
+    "\n}\nis: {" ^ (trie-to-string "\n" include-elt-to-string is) ^
     "\n}\nΓ: {" ^ (ctxt-to-string context) ^ "}"
 
 -- check if a variable is being redefined, and if so return the first given state; otherwise the second (in the monad)
@@ -269,20 +269,20 @@ scope-cmd fn mn oa psₒ asₒ (ImportCmd (Import pi IsPublic pi' ifn oa' asᵢ'
   merged σ (ParamsCons (Decl _ _ me x atk _) ps) ArgsNil =
     merged (trie-insert σ x nothing) ps ArgsNil
   merged σ _ _ = σ
-  
+
   arg-var : arg → maybe var
   arg-var (TermArg me (Var pi x)) = just x
   arg-var (TypeArg (TpVar pi x)) = just x
   arg-var _ = nothing
 
   σ = merged empty-trie psₒ asₒ
-  
+
   reorder : args → args
   reorder (ArgsCons a as) =
     maybe-else' (arg-var a ≫=maybe trie-lookup σ) (ArgsCons a $ reorder as) λ ma →
     maybe-else' ma ArgsNil λ a → ArgsCons a $ reorder as
   reorder ArgsNil = ArgsNil
-  
+
   asᵢ = reorder $ qualif-args (toplevel-state.Γ s) asᵢ'
 
 scope-cmd fn mn oa ps as (DefKind _ v _ _ _) = scope-var fn mn oa ps as v

--- a/src/untyped-spans.agda
+++ b/src/untyped-spans.agda
@@ -50,8 +50,8 @@ untyped-term-spans (Sigma pi t) = untyped-term-spans t ≫span get-ctxt λ Γ �
 untyped-term-spans (Theta pi θ t ls) = untyped-term-spans t ≫span untyped-lterms-spans ls ≫span get-ctxt λ Γ → spanM-add (Theta-span Γ pi θ t ls untyped [] nothing)
 untyped-term-spans (Var pi x) = get-ctxt λ Γ →
   spanM-add (Var-span Γ pi x untyped [] (if ctxt-binds-var Γ x then nothing else just "This variable is not currently in scope."))
-untyped-term-spans (Mu pi x t ot pi' cs pi'') = spanM-add (Mu-span t [] nothing) 
-untyped-term-spans (Mu' pi t ot pi' cs pi'')  = spanM-add (Mu-span t [] nothing) 
+untyped-term-spans (Mu pi x t ot pi' cs pi'') = spanM-add (Mu-span t [] nothing)
+untyped-term-spans (Mu' pi t ot pi' cs pi'')  = spanM-add (Mu-span t [] nothing)
 
 untyped-type-spans (Abs pi b pi' x atk T) = untyped-tk-spans atk ≫span spanM-add (TpQuant-span (me-unerased b) pi x atk T untyped [] nothing) ≫span untyped-var-spans pi' x (if tk-is-type atk then Var-span else TpVar-span) (untyped-type-spans T)
 untyped-type-spans (Iota pi pi' x T T') = untyped-type-spans T ≫span spanM-add (Iota-span pi T' untyped [] nothing) ≫span untyped-var-spans pi' x TpVar-span (untyped-type-spans T')


### PR DESCRIPTION
Just a quality-of-life improvement. Agda will recompile files that only have changed whitespace. Forgive me for having to recompile, but normalizing whitespace will make (my) life easier. :)

You can run `make whitespace` to cleanup the repo. Or add `(add-hook 'before-save-hook 'delete-trailing-whitespace)` to your emacs init file.

I'll probably just merge this after a day or two unless someone objects.