### PR TITLE
Add @direntry command to documentation texinfo

### DIFF
--- a/docs/src/cedille-info-main.texi
+++ b/docs/src/cedille-info-main.texi
@@ -4,6 +4,11 @@
 @documentencoding UTF-8
 @paragraphindent 0
 
+@dircategory Programming
+@direntry
+* Cedille: (cedille-info-main).       Cedille Documentation
+@end direntry
+
 @include version-macro.texi
 
 @ifnottex


### PR DESCRIPTION
The `@direntry` command is required in order for the Info file to work
correctly with `install-info`.
See: https://www.gnu.org/software/texinfo/manual/texinfo/html_node/Installing-Dir-Entries.html