### PR TITLE
Use #!usr/bin/env as shebang

### DIFF
--- a/cedille-tests/run-tests.sh
+++ b/cedille-tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 init=
 debug=

--- a/create-libraries.sh
+++ b/create-libraries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f libraries
 

--- a/docs/src/compile-docs.sh
+++ b/docs/src/compile-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # to be run in docs/src/ because of the relative path
 
 makeinfo -o ../info/cedille-info-main.info cedille-info-main.texi

--- a/packages/mac/Cedille
+++ b/packages/mac/Cedille
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 


### PR DESCRIPTION
The advantage of using `#!/usr/bin/env` is that it will lookup the executable in the user's $PATH.