### PR TITLE
CI Tests for new-libs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ial"]
 	path = ial
-	url = ../ial.git
+	url = https://github.com/cedille/ial.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,4 @@ install:
 
 script:
   - make
-    #- make cedille-lib
   - make cedille-newlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
   - $HOME/.ghc
   - $HOME/.cabal
+  - ${TRAVIS_BUILD_DIR}/bin
 
 before_install:
   - export PATH=~/.cabal/bin:/opt/cabal/$CABAL_VER/bin:/opt/ghc/$GHC_VER/bin:$PATH
@@ -30,6 +31,6 @@ install:
   - travis_wait 25 cabal install agda-2.5.4
 
 script:
-  - make -j32
+  - make
     #- make cedille-lib
   - make cedille-newlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
   - $HOME/.ghc
   - $HOME/.cabal
-  - ${TRAVIS_BUILD_DIR}/bin
+  - bin
 
 before_install:
   - export PATH=~/.cabal/bin:/opt/cabal/$CABAL_VER/bin:/opt/ghc/$GHC_VER/bin:$PATH
@@ -32,4 +32,4 @@ install:
 
 script:
   - make
-  - make cedille-newlib
+  - make cedille-lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,6 @@ install:
   - travis_wait 25 cabal install agda-2.5.4
 
 script:
-  - make
+  - make -j32
+    #- make cedille-lib
+  - make cedille-newlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ install:
 
 script:
   - make
-  - make cedille-lib
+  - make tests

--- a/Makefile
+++ b/Makefile
@@ -151,13 +151,13 @@ cedille-static: 	$(CEDILLE_DEPS)
 		mv $(SRCDIR)/main $@
 
 .PHONY: cedille-libs
-cedille-lib: $(CEDLIB)
+cedille-lib: cedille $(CEDLIB)
 
-cedille-newlib: $(CEDNEWLIB)
+cedille-newlib: cedille $(CEDNEWLIB)
 
 .PHONY: %.ced
 %.ced : FORCE
-	cedille $@
+	bin/cedille $@
 
 FORCE:
 

--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,11 @@ TEMPLATES = $(TEMPLATESDIR)/Mendler.ced $(TEMPLATESDIR)/MendlerSimple.ced
 FILES = $(AUTOGEN) $(AGDASRC)
 
 SRC = $(FILES:%=$(SRCDIR)//%)
-CEDLIB := $(shell find $(CEDLIBDIR) -name '*.ced')
+CEDLIB = $(shell find $(CEDLIBDIR) -name '*.ced')
 
-# CEDLIBNAMES = $(notdir $(CEDLIB))
-# ELABLIB := $(CEDLIBNAMES:%.ced=$(ELABDIR)/%.cdle)
-ELABLIB = $(shell find $(ELABDIR) -name '*.cdle')
+# FIXME: For some reason this variable expansion is eager instead of lazy
+ELABLIB=$(shell find $(ELABDIR) -name '*.cdle')
+
 OBJ = $(SRC:%.agda=%.agdai)
 
 LIB = --library-file=libraries --library=ial --library=cedille
@@ -155,16 +155,20 @@ cedille-static: 	$(CEDILLE_DEPS)
 		$(CEDILLE_BUILD_CMD) --ghc-flag=-optl-static --ghc-flag=-optl-pthread -c $(SRCDIR)/main.agda
 		mv $(SRCDIR)/main $@
 
-cedille-lib: cedille $(CEDLIB) $(ELABLIB)
+tests: cedille elab-lib
+
+elab-lib:
+	mkdir -p ${ELABDIR}
+	make ${CEDLIB}
+	# FIXME: Workaround for $(ELABLIB) being eager
+	make $(ELABDIR)/*
+
 
 %.ced : FORCE
 	bin/cedille -e $@ $(ELABDIR)
 
 %.cdle : FORCE
 	bin/cedille $@
-
-ECHONAMES:
-	@echo $(ELABLIB)
 
 FORCE:
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ AGDA=agda
 
 SRCDIR=src
 
+CEDLIBDIR=lib
+CEDNEWLIBDIR=new-lib
+
 AUTOGEN = \
 	cedille.agda \
 	cedille-types.agda \
@@ -88,6 +91,8 @@ TEMPLATES = $(TEMPLATESDIR)/Mendler.ced $(TEMPLATESDIR)/MendlerSimple.ced
 FILES = $(AUTOGEN) $(AGDASRC)
 
 SRC = $(FILES:%=$(SRCDIR)//%)
+CEDLIB := $(shell find $(CEDLIBDIR) -name '*.ced')
+CEDNEWLIB := $(shell find $(CEDNEWLIBDIR) -name '*.ced')
 OBJ = $(SRC:%.agda=%.agdai)
 
 LIB = --library-file=libraries --library=ial --library=cedille
@@ -118,7 +123,7 @@ libraries: ./ial/ial.agda-lib
 $(TEMPLATESDIR)/TemplatesCompiler: $(TEMPLATESDIR)/TemplatesCompiler.hs ./src/CedilleParser.hs
 	cd $(TEMPLATESDIR); ghc -dynamic --make -i../ TemplatesCompiler.hs
 
-./src/Templates.hs: $(TEMPLATES) $(TEMPLATESDIR)/TemplatesCompiler 
+./src/Templates.hs: $(TEMPLATESDIR)/TemplatesCompiler
 	$(TEMPLATESDIR)/TemplatesCompiler
 
 ./core/cedille-core: $(CEDILLE_CORE)
@@ -134,10 +139,22 @@ CEDILLE_BUILD_CMD_DYN = $(CEDILLE_BUILD_CMD) --ghc-flag=-dynamic
 cedille:	$(CEDILLE_DEPS)
 		$(CEDILLE_BUILD_CMD_DYN) -c $(SRCDIR)/main.agda
 		mv $(SRCDIR)/main $@
+		#make $(TEMPLATES)
 
 cedille-static: 	$(CEDILLE_DEPS)
 		$(CEDILLE_BUILD_CMD) --ghc-flag=-optl-static --ghc-flag=-optl-pthread -c $(SRCDIR)/main.agda
 		mv $(SRCDIR)/main $@
+
+.PHONY: cedille-libs
+cedille-lib: $(CEDLIB)
+
+cedille-newlib: $(CEDNEWLIB)
+
+.PHONY: %.ced
+%.ced : FORCE
+	cedille $@
+
+FORCE:
 
 .PHONY: cedille-docs
 cedille-docs: docs/info/cedille-info-main.info

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SRCDIR=src
 CEDLIBDIR=new-lib
 
 ELABDIR=elab
+LANGOVERVIEWDIR=language-overview
 
 AUTOGEN = \
 	cedille.agda \
@@ -94,7 +95,8 @@ TEMPLATES = $(TEMPLATESDIR)/Mendler.ced $(TEMPLATESDIR)/MendlerSimple.ced
 FILES = $(AUTOGEN) $(AGDASRC)
 
 SRC = $(FILES:%=$(SRCDIR)//%)
-CEDLIB = $(shell find $(CEDLIBDIR) -name '*.ced')
+CEDLIB = $(shell find $(CEDLIBDIR) -name '*.ced') 
+LANGOVERVIEWLIB=$(shell find $(LANGOVERVIEWDIR) -name '*.ced')
 
 # FIXME: For some reason this variable expansion is eager instead of lazy
 ELABLIB=$(shell find $(ELABDIR) -name '*.cdle')
@@ -155,14 +157,26 @@ cedille-static: 	$(CEDILLE_DEPS)
 		$(CEDILLE_BUILD_CMD) --ghc-flag=-optl-static --ghc-flag=-optl-pthread -c $(SRCDIR)/main.agda
 		mv $(SRCDIR)/main $@
 
-tests: cedille elab-lib
+tests: cedille elab-all
+
 
 # FIXME: Workaround for $(ELABLIB) being eager
-elab-lib:
-	mkdir -p ${ELABDIR}
+elab-all:
+	#mkdir -p ${ELABDIR}
+	$(MAKE) elab-lib
+	$(MAKE) clean-elabdir
+	$(MAKE) elab-langoverview
+
+elab-lib: 
 	${MAKE} ${CEDLIB}
 	${MAKE} $(ELABDIR)/*
 
+elab-langoverview:
+	${MAKE} $(LANGOVERVIEWLIB)
+	${MAKE} $(ELABDIR)/*
+
+clean-elabdir: FORCE
+	rm $(ELABDIR)/*
 
 %.ced : FORCE
 	bin/cedille -e $@ $(ELABDIR)

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,12 @@ CEDILLE_DEPS = $(SRC) Makefile libraries ./ial/ial.agda-lib ./src/CedilleParser.
 CEDILLE_BUILD_CMD = $(AGDA) $(LIB) --ghc-flag=-rtsopts 
 CEDILLE_BUILD_CMD_DYN = $(CEDILLE_BUILD_CMD) --ghc-flag=-dynamic 
 
-cedille:	$(CEDILLE_DEPS)
+cedille: bin $(CEDILLE_DEPS) bin/cedille
+
+bin :
+	mkdir -p bin
+
+bin/cedille:
 		$(CEDILLE_BUILD_CMD_DYN) -c $(SRCDIR)/main.agda
 		mv $(SRCDIR)/main $@
 		#make $(TEMPLATES)

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ TEMPLATES = $(TEMPLATESDIR)/Mendler.ced $(TEMPLATESDIR)/MendlerSimple.ced
 FILES = $(AUTOGEN) $(AGDASRC)
 
 SRC = $(FILES:%=$(SRCDIR)//%)
-CEDLIB = 'new-lib/data/nat.ced' #$(shell find $(CEDLIBDIR) -name '*.ced')
+CEDLIB = $(shell find $(CEDLIBDIR) -name '*.ced')
 
 # FIXME: For some reason this variable expansion is eager instead of lazy
 ELABLIB=$(shell find $(ELABDIR) -name '*.cdle')

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ TEMPLATES = $(TEMPLATESDIR)/Mendler.ced $(TEMPLATESDIR)/MendlerSimple.ced
 FILES = $(AUTOGEN) $(AGDASRC)
 
 SRC = $(FILES:%=$(SRCDIR)//%)
-CEDLIB = $(shell find $(CEDLIBDIR) -name '*.ced')
+CEDLIB = 'new-lib/data/nat.ced' #$(shell find $(CEDLIBDIR) -name '*.ced')
 
 # FIXME: For some reason this variable expansion is eager instead of lazy
 ELABLIB=$(shell find $(ELABDIR) -name '*.cdle')
@@ -157,11 +157,11 @@ cedille-static: 	$(CEDILLE_DEPS)
 
 tests: cedille elab-lib
 
+# FIXME: Workaround for $(ELABLIB) being eager
 elab-lib:
 	mkdir -p ${ELABDIR}
-	make ${CEDLIB}
-	# FIXME: Workaround for $(ELABLIB) being eager
-	make $(ELABDIR)/*
+	${MAKE} ${CEDLIB}
+	${MAKE} $(ELABDIR)/*
 
 
 %.ced : FORCE

--- a/cedille-mode.el
+++ b/cedille-mode.el
@@ -28,10 +28,10 @@
 
 (defvar cedille-program-name
   (cedille-platform-case
-   "cedille"
+   "bin/cedille"
    nil
-   "cedille"
-   (concat (file-name-as-directory cedille-path) "cedille")))
+   "bin/cedille"
+   (concat (file-name-as-directory cedille-path) "bin/cedille")))
 
 (defvar cedille-core-program-name
   (cedille-platform-case

--- a/language-overview/local-definitions.ced
+++ b/language-overview/local-definitions.ced
@@ -19,9 +19,9 @@ num2 : Nat = [num1 = suc zero] - [num1' = suc zero] - suc num1.
 -- helpful for carrying out proofs with erased premises, e.g.
 -}
 
-eq-trans1-fail : ∀ A: ★. Π x: A. Π y: A. Π z: A. {x ≃ y} ➾ {y ≃ z} ➾ {x ≃ z}
-  = Λ A. λ x. λ y. λ z. Λ eqxy. Λ eqyz. -- <-- error: occurs free in the erasure of body
-    [eqxz : {x ≃ z} = ρ eqxy - eqyz] - eqxz.
+-- eq-trans1-fail : ∀ A: ★. Π x: A. Π y: A. Π z: A. {x ≃ y} ➾ {y ≃ z} ➾ {x ≃ z}
+  -- = Λ A. λ x. λ y. λ z. Λ eqxy. Λ eqyz. -- <-- error: occurs free in the erasure of body
+    -- [eqxz : {x ≃ z} = ρ eqxy - eqyz] - eqxz.
 
 eq-trans1 : ∀ A: ★. Π x: A. Π y: A. Π z: A. {x ≃ y} ➾ {y ≃ z} ➾ {x ≃ z}
   = Λ A. λ x. λ y. λ z. Λ eqxy. Λ eqyz.
@@ -31,9 +31,9 @@ eq-trans1 : ∀ A: ★. Π x: A. Π y: A. Π z: A. {x ≃ y} ➾ {y ≃ z} ➾ {
 -- its body, you can use {} instead of [] for the let expression
 -}
 
-eq-trans2-fail : ∀ A: ★. Π x: A. Π y: A. Π z: A. {x ≃ y} ➾ {y ≃ z} ➾ {x ≃ z}
-  = Λ A. λ x. λ y. λ z. Λ eqxy. Λ eqyz.
-    {eqxz : {x ≃ z} = ρ eqxy - eqyz} - eqxz.
+-- eq-trans2-fail : ∀ A: ★. Π x: A. Π y: A. Π z: A. {x ≃ y} ➾ {y ≃ z} ➾ {x ≃ z}
+  -- = Λ A. λ x. λ y. λ z. Λ eqxy. Λ eqyz.
+    -- {eqxz : {x ≃ z} = ρ eqxy - eqyz} - eqxz.
 --   ^--^
 --   |__|__ error: occurs free in the body
 

--- a/language-overview/obviously-false-equations.ced
+++ b/language-overview/obviously-false-equations.ced
@@ -11,5 +11,5 @@ ff' ◂ Bool' = Λ X . λ a . λ b . b.
    is interpreted as meaning that the sides of the equation
    are beta-eta equal. -}
 
-BoolContra ◂ {tt' ≃ ff'} ➾ False =
-  Λ e . δ - e . 
+-- BoolContra ◂ {tt' ≃ ff'} ➾ False =
+--   Λ e . δ - e . 

--- a/language-overview/opaque-definitions.ced
+++ b/language-overview/opaque-definitions.ced
@@ -53,7 +53,7 @@ ctt : cBool = Λ X. λ t. λ f. t.
 cff : cBool = Λ X. λ t. λ f. f.
 
 rec-tt-lemma-works : { ctt ctt cff ≃ ctt } = β.
-rec-tt-lemma-fails : { ctt ctt cff ≃ ctt } = close ctt - β.
+-- rec-tt-lemma-fails : { ctt ctt cff ≃ ctt } = close ctt - β.
 
 {- This can be convenient if you want the checker to avoid unfolding some
    definition with a huge (head-)normal form. -}

--- a/language-overview/type-inference.ced
+++ b/language-overview/type-inference.ced
@@ -86,7 +86,7 @@ test4 ◂ Bool = const tt id .
       3. the information from preceding arguments
 -}
 
-test5-fail ◂ Bool = const tt (λ x. x) .
+-- test5-fail ◂ Bool = const tt (λ x. x) .
 test5      ◂ Bool = const tt (λ x: Bool. x) .
 
 {-    Here these three sources do not provide enough info to check the argument
@@ -97,7 +97,7 @@ test5      ◂ Bool = const tt (λ x: Bool. x) .
       type quantifier or arrow
 -}
 
-test6-fail ◂ Bot ➔ Bool = λ bot. bot tt .
+-- test6-fail ◂ Bot ➔ Bool = λ bot. bot tt .
 test6      ◂ Bot ➔ Bool = λ bot. bot ·Unit tt .
 
 {-    in `test6-fail` the type of the head does not have an arrow in it, so we
@@ -113,13 +113,13 @@ test6      ◂ Bot ➔ Bool = λ bot. bot ·Unit tt .
       meta-variables are never propagated out of a maximal application.
 -}
 
-test7-fail ◂ (∀ X: ★. ∀ Y: ★. Y ➔ Y) ➔ Bool
-  = λ f. f tt .
+-- test7-fail ◂ (∀ X: ★. ∀ Y: ★. Y ➔ Y) ➔ Bool
+  -- = λ f. f tt .
 
 test7 ◂ (∀ X: ★. ∀ Y: ★. Y ➔ Y) ➔ Bool
   = λ f. f ·Unit tt .
 
-test8-fail = mkpair tt .
+-- test8-fail = mkpair tt .
 
 test8 = Λ Y: ★. mkpair ·Bool ·Y tt .
 

--- a/src/elab-util.agda
+++ b/src/elab-util.agda
@@ -1086,4 +1086,4 @@ elab-write-all ei@(mk-elab-info τ ρ φ ν) to =
 elab-all : toplevel-state → (from to : filepath) → IO ⊤
 elab-all ts fm to =
   elab-write-all (fst (elab-file (new-elab-info ts) fm)) to >>
-  putStrLn "0"
+  putStrLn ("0")

--- a/src/main.agda
+++ b/src/main.agda
@@ -124,7 +124,7 @@ module main-with-options
   (compileTime : UTC)
   (options-filepath : filepath)
   (options : cedille-options.options)
-  (die : IO ⊤) where
+  (die : 𝕃 char → IO ⊤) where
 
   open import ctxt
   --open import instances
@@ -499,7 +499,7 @@ module main-with-options
           finish input-filename s = --return triv
             let ie = get-include-elt s input-filename in
             if include-elt.err ie
-            then die -- ("Compilation Failed")
+            then die (string-to-𝕃char ("Compilation Failed"))
             else return triv
 
   -- this is the case where we will go into a loop reading commands from stdin, from the fronted
@@ -519,7 +519,7 @@ postulate
   setStdinNewlineMode : IO ⊤
   compileTime : UTC
   templatesDir : filepath
-  die : IO ⊤
+  die : 𝕃 char → IO ⊤
 
 {-# FOREIGN GHC {-# LANGUAGE TemplateHaskell #-} #-}
 {-# FOREIGN GHC import qualified System.IO #-}
@@ -528,7 +528,7 @@ postulate
 {-# FOREIGN GHC import qualified Data.Time.Format #-}
 {-# FOREIGN GHC import qualified Data.Time.Clock.POSIX #-}
 {-# FOREIGN GHC import qualified Language.Haskell.TH.Syntax #-}
-{-# COMPILE GHC die = System.Exit.exitFailure #-}
+{-# COMPILE GHC die = System.Exit.die #-}
 {-# COMPILE GHC initializeStdinToUTF8 = System.IO.hSetEncoding System.IO.stdin System.IO.utf8 #-}
 {-# COMPILE GHC setStdinNewlineMode = System.IO.hSetNewlineMode System.IO.stdin System.IO.universalNewlineMode #-}
 {-# COMPILE GHC compileTime =

--- a/src/main.agda
+++ b/src/main.agda
@@ -496,7 +496,7 @@ module main-with-options
     processFile f >>= λ s →
     let ie = get-include-elt s f in
       if include-elt.err ie
-      then die (string-to-𝕃char ("Elaboration Failed"))
+      then die (string-to-𝕃char ("Type Checking Failed"))
       else return s
 
   -- function to process command-line arguments
@@ -517,7 +517,7 @@ module main-with-options
 
   -- all other cases are errors
   processArgs xs = putStrLn ("Run with the name of one file to process,"
-                           ^ "or run with no command-line arguments and enter the\n"
+                           ^ " or run with no command-line arguments and enter the\n"
                            ^ "names of files one at a time followed by newlines (this is for the emacs mode).")
   main' : 𝕃 string → IO ⊤
   main' args =

--- a/src/main.agda
+++ b/src/main.agda
@@ -493,7 +493,6 @@ module main-with-options
 
   -- function to process command-line arguments
   processArgs : 𝕃 string → IO ⊤
-
   -- this is the case for when we are called with a single command-line argument, the name of the file to process
   processArgs (input-filename :: []) =
     canonicalizePath input-filename >>= λ input-filename' →
@@ -508,8 +507,11 @@ module main-with-options
   -- FIXME: For some reason the parameters get here reversed (?)
   processArgs (to :: fm :: "-e" :: []) =
     canonicalizePath fm >>= λ fm' →
-    processFile fm' >>= λ st →
-    elab-all st fm' to >>r triv
+    processFile fm' >>= λ s →
+    let ie = get-include-elt s fm' in
+    if include-elt.err ie
+    then die (string-to-𝕃char ("Elaboration Failed"))
+    else elab-all s fm' to >>r triv
 
   -- this is the case where we will go into a loop reading commands from stdin, from the fronted
   processArgs [] = readCommandsFromFrontend (new-toplevel-state (cedille-options.options.include-path options))


### PR DESCRIPTION
This closes #93 

The most important things to notice in this pull request are:
- Cedille was silently failing when checking a file directly using the executable. Now it will signal stderr;
- The makefile now installs the executable to a bin directory, making it easier to cache the results in travis;
- It does not elaborate the files, because this feature is only available in interactive mode;
- The ial submodule path didn't work in a fork before.