### PR TITLE
Add a CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Cedille!
 There are, in principle, two paths you should take when contributing to Cedille.
 If you have found an existing issue that you think you are a good fit for implementing then you should comment on that issue to request input from the development.
 If you have a feature request, you should open an issue describing your request in as much detail that is reasonable so that the development team can understand and give an adequate response.
-Please refrain from opening a pull request directly without having some initial contact (and, preferably, and established line of communication) with someone at the development team.
+Please refrain from opening a pull request directly without having some initial contact (and, preferably, an established line of communication) with someone at the development team.
 
 Note that issues on the Cedille repository may occassionally be placeholders for more complicated features that the development has not yet fleshed out.
 If an issue seems light on substance, you should be suspicious that it is a good place to start when looking to contribute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to Cedille
+
+Thank you for your interest in contributing to Cedille!
+There are, in principle, two paths you should take when contributing to Cedille.
+If you have found an existing issue that you think you are a good fit for implementing then you should comment on that issue to request input from the development.
+If you have a feature request, you should open an issue describing your request in as much detail that is reasonable so that the development team can understand and give an adequate response.
+Please refrain from opening a pull request directly without having some initial contact (and, preferably, and established line of communication) with someone at the development team.
+
+Note that issues on the Cedille repository may occassionally be placeholders for more complicated features that the development has not yet fleshed out.
+If an issue seems light on substance, you should be suspicious that it is a good place to start when looking to contribute.
+Likewise, feature requests, although welcome, will need to be sufficiently thought out.
+In particular, any feature request that would cause a change to the underlying core theory of Cedille is very unlikely to be accepted without significant argumentation about why the extension would be useful and that it would not endanger the consistency of the theory.


### PR DESCRIPTION
This PR adds a contrib md file with a small excerpt to guide potential contributors into a path of success when desiring to contribute to Cedille.