### PR TITLE
Rename pair to sigma

### DIFF
--- a/new-lib/categories/functor.ced
+++ b/new-lib/categories/functor.ced
@@ -31,9 +31,3 @@ f2raw : ∀ F: ★ ➔ ★. Cast ·(Functor ·F) ·(RawFunctor ·F)
         [ mkRawFunctor fmap , β{mkRawFunctor fmap} ]
       }).
 
-f2castMap : ∀ F : ★ ➔ ★ . Functor · F ➔ CastMap · F =
-  Λ F . λ fu .
-    μ' fu
-      { mkFunctor fmap -fid -fcomp ➔
-        Λ A . Λ B . Λ c .
-          intrCast -(fmap (elimCast -c)) -(fid (elimCast -c) (λ a . β)) }.

--- a/new-lib/data/sigma-thms.ced
+++ b/new-lib/data/sigma-thms.ced
@@ -18,6 +18,6 @@ sndCong : ∀ A1: ★. ∀ B1: A1 ➔ ★. ∀ A2: ★. ∀ B2: A2 ➔ ★.
 
 _ : ∀ A: ★. ∀ B: A ➔ ★. Π p1: Sigma ·A ·B. Π p2: Sigma ·A ·B. {p1 ≃ p2} ➔ {snd p1 ≃ snd p2}
 = Λ A. Λ B. λ p1. λ p2. μ' p1 {
-  | pair a1 b1 ➔ μ' p2 {
-  | pair a2 b2 ➔ λ eq. ρ eq - β
+  | sigma a1 b1 ➔ μ' p2 {
+  | sigma a2 b2 ➔ λ eq. ρ eq - β
   }}.

--- a/new-lib/data/sigma.ced
+++ b/new-lib/data/sigma.ced
@@ -1,28 +1,29 @@
 module sigma.
 
 data Sigma (A: ★) (B: A ➔ ★) : ★ =
-  | pair : Π a: A. Π b: B a. Sigma.
+  | sigma : Π a: A. Π b: B a. Sigma.
 
 Pair : ★ ➔ ★ ➔ ★ = λ A: ★. λ B: ★. Sigma ·A ·(λ _: A. B).
+pair : ∀ A : ★ . ∀ B : ★ . A ➔ B ➔ Pair · A · B = Λ A . Λ B . λ a . λ b . sigma · A · (λ _ : A . B) a b.
 
 fst : ∀ A: ★. ∀ B: A ➔ ★. Sigma ·A ·B ➔ A
-  = Λ A. Λ B. λ p. μ' p {pair a _ ➔ a}.
+  = Λ A. Λ B. λ p. μ' p {sigma a _ ➔ a}.
 
 snd : ∀ A: ★. ∀ B: A ➔ ★. Π p: Sigma ·A ·B. B (fst p)
-  = Λ A. Λ B. λ p. μ' p @(λ x: Sigma ·A ·B. B (fst x)) {pair _ b ➔ b}.
+  = Λ A. Λ B. λ p. μ' p @(λ x: Sigma ·A ·B. B (fst x)) {sigma _ b ➔ b}.
 
 curry : ∀ A: ★. ∀ B: A ➔ ★. ∀ X: ★.
   (Sigma ·A ·B ➔ X) ➔ Π a: A. Π b: B a. X
-= Λ A. Λ B. Λ X. λ f. λ a. λ b. f (pair a b).
+= Λ A. Λ B. Λ X. λ f. λ a. λ b. f (sigma a b).
 
 uncurry : ∀ A: ★. ∀ B: A ➔ ★. ∀ X: ★.
   (Π a: A. Π b: B a. X) ➔ Sigma ·A ·B ➔ X
 = Λ A. Λ B. Λ X. λ f. λ p. μ' p {
-  | pair a b ➔ f a b
+  | sigma a b ➔ f a b
   }.
 
 pairMap
 : ∀ A: ★. ∀ B: ★. ∀ C: ★. ∀ D: ★.
   (A ➔ C) ➔ (B ➔ D) ➔ Pair ·A ·B ➔ Pair ·C ·D
 = Λ A. Λ B. Λ C. Λ D. λ f. λ g. λ p.
-  μ' p {pair a b ➔ pair (f a) (g b)}.
+  μ' p {sigma a b ➔ sigma (f a) (g b)}.


### PR DESCRIPTION
Hi, Chris.  I have a change to propose to the way the library handles dependent and non-dependent pairs.  It is pretty common to build non-dependent pairs, but then our type-inference algorithm often (always?) needs one to supply the B : A -> * type argument.  So I am proposing introducing "pair" as a defined function (where type-inference is then in much better shape), and renaming the constructor for Sigma to sigma.  What do you think?