### PR TITLE
rename maybe-or to ||-maybe

### DIFF
--- a/src/classify.agda
+++ b/src/classify.agda
@@ -239,7 +239,7 @@ check-term Γ (ExIotaPair pi t₁ t₂ Tₘ? pi') Tₑ? =
               to-string-tag "hnf of the first component"  Γ (hnf Γ unfold-head t₁~) ::
             [ to-string-tag "hnf of the second component" Γ (hnf Γ unfold-head t₂~) ] in
       [- IotaPair-span pi pi' (maybe-to-checking Tₑ?) (conv-tvs ++ tvs)
-           (conv-e? maybe-or err?) -]
+           (conv-e? ||-maybe err?) -]
       return-when t~ T~
 
 -- t.(1 / 2)
@@ -315,7 +315,7 @@ check-term Γ (ExLam pi e pi' x tk? t) Tₑ? =
             vₑ = check-for-tpkd-mismatch-if Γ "computed" tk~? tk in
         [- var-span e (Γ , pi' - x :` tk~) pi' x (maybe-to-checking tk?) tk~ nothing -]
         [- uncurry (λ err tvs → Lam-span Γ checking pi pi' e x tk~ t
-                 (type-data Γ Tₛ :: expected-type Γ Tₑ :: tvs) (err maybe-or vₑ))
+                 (type-data Γ Tₛ :: expected-type Γ Tₑ :: tvs) (err ||-maybe vₑ))
              (erase-err e' e tk~ t~) -]
         return (Lam e xₙ (just tk~) t~)
       Tₕ →
@@ -464,7 +464,7 @@ check-term Γ (ExTheta pi θ t ts) Tₑ? =
               t~ = case θ of λ {AbstractEq → AppEr t~ (Beta (erase t~) id-term); _ → t~} in
           [- Theta-span Γ pi θ t ts checking
                (type-data Γ T~ :: expected-type Γ Tₑ :: tvs)
-               (e₁ maybe-or (e₂ maybe-or e₃)) -]
+               (e₁ ||-maybe (e₂ ||-maybe e₃)) -]
           return t~
         Tₕ →
           [- Theta-span Γ pi θ t ts checking (head-type Γ Tₕ :: expected-type Γ Tₑ :: [])
@@ -876,7 +876,7 @@ check-case Γ (ExCase pi x cas t) es Dₓ cs ρₒ as dps Tₘ cast-tm cast-tp =
       (trie-insert σ x' (, Var (pi % x)))
       (renamectxt-insert ρ (pi % x) xₙ)
       (binder-data Γ' pi x (Tkt T') (ex-case-arg-erased me) nothing spos epos :: xs)
-      λ t → [- Var-span Γ' pi x checking [ type-data Γ T' ] (e₁ maybe-or e₂ t) -] sm t
+      λ t → [- Var-span Γ' pi x checking [ type-data Γ T' ] (e₁ ||-maybe e₂ t) -] sm t
   decl-args Γ (ExCaseArg me pi x :: as) (Param me' x' (Tkk k) :: ps) σ ρ xs sm =
     let k' = substs Γ σ k
         Γ' = ctxt-var-decl-loc pi x Γ
@@ -971,8 +971,8 @@ ctxt-mu-decls Γ t is Tₘ (mk-data-info X Xₒ asₚ asᵢ ps kᵢ k cs csₚ�
       e₃ = λ x → just $ x ^ " occurs free in the erasure of the body (not allowed)"
       cs-fvs = stringset-contains ∘' free-vars-cases ∘' erase-cases
       e₃ₓ? = λ cs x → maybe-if (cs-fvs cs x) >> e₃ x
-      e₃? = λ cs → e₃ₓ? cs (mu-isType/ x) maybe-or e₃ₓ? cs (mu-Type/ x) in
-    (λ cs → [- var-span NotErased Γ'' pi₁ x checking (Tkt Tₓ) (e₂? maybe-or e₃? cs) -] spanMok) ,
+      e₃? = λ cs → e₃ₓ? cs (mu-isType/ x) ||-maybe e₃ₓ? cs (mu-Type/ x) in
+    (λ cs → [- var-span NotErased Γ'' pi₁ x checking (Tkt Tₓ) (e₂? ||-maybe e₃? cs) -] spanMok) ,
      Γ'' ,
     (binder-data Γ'' pi₁ X' (Tkk k) Erased nothing pi₂ pi₃ ::
      binder-data Γ'' pi₁ xₘᵤ (Tkt Tₘᵤ) Erased nothing pi₂ pi₃ ::
@@ -1054,7 +1054,11 @@ check-mu Γ pi μ t Tₘ? pi'' cs pi''' Tₑ? =
                              (just "A motive is required when synthesizing")
                              (check-for-type-mismatch-if Γ "synthesized" Tₑ?) in
                   [- Mu-span Γ pi μ pi''' Tₘ?' (maybe-to-checking Tₑ?)
-                         (expected-type-if Γ Tₑ? ++ maybe-else' Tᵣ [] (λ Tᵣ → [ type-data Γ Tᵣ ]) ++ tvs₁ ++ bds) (e₁ maybe-or (e₂ maybe-or (e₃ maybe-or eₘ))) -]
+                         (expected-type-if Γ Tₑ? ++
+                           maybe-else' Tᵣ [] (λ Tᵣ → [ type-data Γ Tᵣ ]) ++
+                           tvs₁ ++
+                           bds)
+                         (e₁ ||-maybe (e₂ ||-maybe (e₃ ||-maybe eₘ))) -]
                   sm cs~ >>
                   let μ = case μ of λ {(ExIsMu pi x) → inj₂ x; (ExIsMu' _) → inj₁ (just tₑ~)} in
                   return-when {m = Tₑ?}

--- a/src/conversion.agda
+++ b/src/conversion.agda
@@ -140,7 +140,7 @@ hnf {TERM} Γ u (Mu μₒ tₒ _ t~ cs') =
                           conv-ctr-ps Γ cₓ' cₓ ≫=maybe uncurry λ ps' ps →
                           maybe-if (length as =ℕ length cas + ps) ≫=maybe λ _ →
                           just (t , cas , drop ps as)}
-      matching-case = λ cₓ as → foldr (_maybe-or_ ∘ case-matches cₓ as) nothing cs
+      matching-case = λ cₓ as → foldr (_||-maybe_ ∘ case-matches cₓ as) nothing cs
       sub-mu = let x = fresh-var Γ "x" in , Lam ff x nothing (t-else (Var x))
       sub = λ Γ → either-else' μₒ (λ _ → id {A = term})
         (λ x → substs Γ (trie-insert (trie-single x sub-mu) (data-to/ x) (, id-term))) in
@@ -344,7 +344,7 @@ inconv Γ t₁ t₂ = inconv-lams empty-renamectxt empty-renamectxt
     where
     matching-case : case → maybe (term × ℕ × ℕ)
     matching-case (Case x _ _ _) = foldl (λ where
-      (Case xₘ cas tₘ _) m? → m? maybe-or
+      (Case xₘ cas tₘ _) m? → m? ||-maybe
         (conv-ctr-ps Γ xₘ x ≫=maybe uncurry λ psₘ ps →
          just (case-args-to-lams cas tₘ , length cas , ps)))
       nothing ms₂

--- a/src/datatype-util.agda
+++ b/src/datatype-util.agda
@@ -100,12 +100,12 @@ module positivity (x : var) where
 
   arrs+ Γ (TpAbs me x' atk T) =
     let Γ' = ctxt-var-decl x' Γ in
-    occurs (tpkd+ Γ $ hnf' Γ -tk atk) maybe-or arrs+ Γ' (hnf' Γ' T)
+    occurs (tpkd+ Γ $ hnf' Γ -tk atk) ||-maybe arrs+ Γ' (hnf' Γ' T)
   arrs+ Γ (TpApp T tT) = occurs (tpapp+ Γ $ hnf' Γ (TpApp T tT))
                        --arrs+ Γ T maybe-or (not-free -tT' tT)
   arrs+ Γ (TpLam x' atk T) =
     let Γ' = ctxt-var-decl x' Γ in
-    occurs (tpkd+ Γ $ hnf' Γ -tk atk) maybe-or arrs+ Γ' (hnf' Γ' T)
+    occurs (tpkd+ Γ $ hnf' Γ -tk atk) ||-maybe arrs+ Γ' (hnf' Γ' T)
   arrs+ Γ (TpVar x') = maybe-if (~ x =string x') >> just ff
   arrs+ Γ T = just ff
   

--- a/src/elab-util.agda
+++ b/src/elab-util.agda
@@ -861,7 +861,7 @@ mendler-elab-mu Γ (mk-data-info X Xₒ asₚ asᵢ ps kᵢ k cs csₚₛ (mk-en
                 Rho (Sigma (Var eₓ)) xₓ (TpAppTm (recompose-tpapps (drop (length asₚ) asₜₚ) Tₘ) (Var xₓ)) t})
               empty-trie ms
       in-fix = λ is/X? T asᵢ t → either-else' x?
-        (λ e → maybe-else' (is/X? maybe-or e) t λ is/X → App (recompose-apps asᵢ (AppEr (AppTp (AppTp cast-out T) Xₜₚ) (App (AppTp is/X (to-tp T)) (Lam ff "to" (just (Tkt (to-tp T))) $ Lam ff "out" (just (Tkt (out-tp T))) $ Var "to")))) t)
+        (λ e → maybe-else' (is/X? ||-maybe e) t λ is/X → App (recompose-apps asᵢ (AppEr (AppTp (AppTp cast-out T) Xₜₚ) (App (AppTp is/X (to-tp T)) (Lam ff "to" (just (Tkt (to-tp T))) $ Lam ff "out" (just (Tkt (out-tp T))) $ Var "to")))) t)
         (λ x → App (recompose-apps asᵢ (AppEr (AppTp fix-in TypeF/D) fmap/D)) (maybe-else' is/X? t λ is/X →
         App (recompose-apps asᵢ (AppEr (AppTp (AppTp cast-out (TpAppTp TypeF/D T)) (TpAppTp TypeF/D Xₜₚ)) (AppEr (AppTp (AppTp fmap/D T) Xₜₚ) (App (AppTp is/X (to-tp T)) (Lam ff "to" (just (Tkt (to-tp T))) $ Lam ff "out" (just (Tkt (out-tp T))) $ Var "to"))))) t))
       app-lambek = λ is/X? t T asᵢ body → AppEr (AppEr body (in-fix is/X? T asᵢ t))

--- a/src/general-util.agda
+++ b/src/general-util.agda
@@ -29,9 +29,9 @@ maybe-equal? f (just x) nothing = ff
 maybe-equal? f nothing (just x) = ff
 maybe-equal? f nothing nothing = tt
 
-_maybe-or_ : ∀ {ℓ} {A : Set ℓ} → maybe A → maybe A → maybe A
-(nothing maybe-or ma) = ma
-(just a  maybe-or ma) = just a
+_||-maybe_ : ∀ {ℓ} {A : Set ℓ} → maybe A → maybe A → maybe A
+(nothing ||-maybe ma) = ma
+(just a  ||-maybe ma) = just a
 
 maybe-not : ∀ {ℓ} {A : Set ℓ} → maybe A → maybe ⊤
 maybe-not (just a) = nothing

--- a/src/process-cmd.agda
+++ b/src/process-cmd.agda
@@ -174,7 +174,7 @@ process-cmd s (ExCmdImport (ExImport pi op pi' x oa as pi'')) =
           (maybe-else' (lookup-mod-params (toplevel-state.Γ s) fnₒ) [] id) >>=c λ e as~ →
          let s-e = scope-file s fnₒ fnᵢ oa' as~
              Γ = toplevel-state.Γ s in
-         [- Import-span pi fnᵢ pi'' [] (snd s-e maybe-or e) -]
+         [- Import-span pi fnᵢ pi'' [] (snd s-e ||-maybe e) -]
          return2 (fst s-e) (CmdImport (Import op fnᵢ x oa' as~))
   where
   -- When importing a file publicly, you may use any number of arguments as long as the
@@ -299,7 +299,7 @@ process-file s filename pn | ie =
              filename pn x empty-spans >>= λ where
        ((mk-toplevel-state ip fns is Γ , f) , ss) →
          let ret-mod = ctxt.fn Γ , ctxt.mn Γ , ctxt.ps Γ , ctxt.qual Γ
-             ie'' = if do-check then set-spans-include-elt ie' ss f else record ie' { ast~ = include-elt.ast~ ie' maybe-or just f } in
+             ie'' = if do-check then set-spans-include-elt ie' ss f else record ie' { ast~ = include-elt.ast~ ie' ||-maybe just f } in
          progress-update pn >> return
            (mk-toplevel-state ip (if do-check then (filename :: fns) else fns) (trie-insert is filename ie'')
              (ctxt-set-current-mod Γ prev-mod) ,

--- a/src/spans.agda
+++ b/src/spans.agda
@@ -167,7 +167,7 @@ location-data (file-name , pi) = strRunTag "location" empty-ctxt (strAdd file-na
 var-location-data : ctxt → var → tagged-val
 var-location-data Γ x =
   location-data (maybe-else missing-location snd
-    (trie-lookup (ctxt.i Γ) x maybe-or trie-lookup (ctxt.i Γ) (qualif-var Γ x)))
+    (trie-lookup (ctxt.i Γ) x ||-maybe trie-lookup (ctxt.i Γ) (qualif-var Γ x)))
 
 explain : string → tagged-val
 explain = strRunTag "explanation" empty-ctxt ∘ strAdd

--- a/src/syntax-util.agda
+++ b/src/syntax-util.agda
@@ -304,7 +304,7 @@ unqual-local : var → var
 unqual-local v = f' (string-to-𝕃char v) where
   f : 𝕃 char → maybe (𝕃 char)
   f [] = nothing
-  f ('@' :: t) = f t maybe-or just t
+  f ('@' :: t) = f t ||-maybe just t
   f (h :: t) = f t
   f' : 𝕃 char → string
   f' (meta-var-pfx :: t) = maybe-else' (f t) v (𝕃char-to-string ∘ _::_ meta-var-pfx)
@@ -326,9 +326,9 @@ reprefix f x =
   ret pfx sfx = just (𝕃char-to-string (reverse pfx) , 𝕃char-to-string sfx)
   pfx : 𝕃 char → 𝕃 char → maybe (var × var)
   pfx (qual-global-chr :: xs) acc =
-    pfx xs (qual-global-chr :: acc) maybe-or ret (qual-global-chr :: acc) xs
+    pfx xs (qual-global-chr :: acc) ||-maybe ret (qual-global-chr :: acc) xs
   pfx (qual-local-chr :: xs) acc =
-    pfx xs (qual-local-chr :: acc) maybe-or ret (qual-local-chr :: acc) xs
+    pfx xs (qual-local-chr :: acc) ||-maybe ret (qual-local-chr :: acc) xs
   pfx (x :: xs) acc = pfx xs (x :: acc)
   pfx [] pfx = nothing
 

--- a/src/toplevel-state.agda
+++ b/src/toplevel-state.agda
@@ -218,7 +218,7 @@ error-in-import-string = "There is an error in the imported file"
 {-# TERMINATING #-}
 check-cyclic-imports : (original current : filepath) → stringset → (path : 𝕃 string) → toplevel-state → err-m
 check-cyclic-imports fnₒ fn fs path s with stringset-contains fs fn
-...| ff = foldr (λ fnᵢ x → x maybe-or check-cyclic-imports fnₒ fnᵢ (stringset-insert fs fn) (fn :: path) s)
+...| ff = foldr (λ fnᵢ x → x ||-maybe check-cyclic-imports fnₒ fnᵢ (stringset-insert fs fn) (fn :: path) s)
             nothing (include-elt.deps (get-include-elt s fn))
 ...| tt with fnₒ =string fn
 ...| tt = just (foldr (λ fnᵢ x → x ^ " → " ^ fnᵢ) ("Cyclic dependencies (" ^ fn) path ^ " → " ^ fn ^ ")")
@@ -230,7 +230,7 @@ scope-t X = filepath → string → maybe var → params → args → X → topl
 infixl 0 _>>=scope_
 _>>=scope_ : toplevel-state × err-m → (toplevel-state → toplevel-state × err-m) → toplevel-state × err-m
 _>>=scope_ (ts , err) f with f ts
-...| ts' , err' = ts' , err maybe-or err'
+...| ts' , err' = ts' , err ||-maybe err'
 
 {-# TERMINATING #-}
 scope-file : toplevel-state → (original imported : filepath) → maybe var → args → toplevel-state × err-m

--- a/src/untyped-spans.agda
+++ b/src/untyped-spans.agda
@@ -384,7 +384,7 @@ untyped-case Γ (ExCase pi x cas t) csₗ asₗ ρ =
                  ("Constructor's datatype has " ^ ℕ-to-string Cₗ ^
                   (if Cₗ =ℕ 1 then " constructor" else " constructors") ^
                   ", but expected " ^ ℕ-to-string csₗ) in
-      [- Var-span Γ pi x untyped [] (asₗ cᵢ maybe-or (eₐ maybe-or eₗ)) -]
+      [- Var-span Γ pi x untyped [] (asₗ cᵢ ||-maybe (eₐ ||-maybe eₗ)) -]
       return2 c~ ((λ cᵢ' → when (cᵢ =ℕ cᵢ') eᵢ) , (maybe-not (asₗ cᵢ) >> just cᵢ))
     _ →
       [- Var-span Γ pi x untyped [] (just $ "This is not a valid constructor name") -]


### PR DESCRIPTION
The rationale for this change is to make it easier to parse
expressions in the code using this infix binary operator.  I was
seeing things like

blah yak maybe-or yak yak

and it took a while to realize that the maybe-or was the outermost
operator; it looked like it could be another argument to blah.

I am suggesting that maybe use of a leading symbol that suggests an operator could help with this problem.  I am not sure I want to hunt for and change all such, but this one puzzled me and made me want to change it.

I just did the renaming.  In one other place I changed some formatting around a use of ||-maybe