### PR TITLE
Fix #130: add support for macOS install locations

### DIFF
--- a/cedille-mode.el
+++ b/cedille-mode.el
@@ -29,14 +29,14 @@
 (defvar cedille-program-name
   (cedille-platform-case
    "bin/cedille"
-   nil
+   "cedille"
    "bin/cedille"
    (concat (file-name-as-directory cedille-path) "bin/cedille")))
 
 (defvar cedille-core-program-name
   (cedille-platform-case
    "cedille-core"
-   nil
+   "cedille-core"
    "cedille-core"
    (concat (file-name-as-directory (concat (file-name-as-directory cedille-path) "core")) "cedille-core")))
 
@@ -45,7 +45,7 @@
   (file-name-as-directory
    (cedille-platform-case
     "C:\\Program Files\\cedille"
-    nil
+    "/usr/local/share/emacs/site-lisp/cedille"
     "/usr/share/emacs/site-lisp/cedille-mode"
     cedille-path)))
 


### PR DESCRIPTION
I'm a little bit confused about why the other systems prefix the `cedille-program-name` with `bin/`, but I haven't investigated what their setup is. In the Homebrew formula `cedille` is on the path, so we can reference it directly here.