### PR TITLE
Remove record in qualified name to let Agda 2.6.1 happy

### DIFF
--- a/src/to-string.agda
+++ b/src/to-string.agda
@@ -102,9 +102,9 @@ need-parens {TYPE} {_} (TpApp T tT) p lr = ~ is-arrow p && (~ is-type-level-app 
 need-parens {TYPE} {_} (TpLam x tk T) p lr = tt
 need-parens {KIND} {_} (KdAbs x tk k) p lr = ~ is-arrow p || is-left lr
 
-pattern ced-ops-drop-spine = cedille-options.options.mk-options _ _ _ _ ff _ _ _ ff _ _
-pattern ced-ops-conv-arr = cedille-options.options.mk-options _ _ _ _ _ _ _ _ ff _ _
-pattern ced-ops-conv-abs = cedille-options.options.mk-options _ _ _ _ _ _ _ _ tt _ _
+pattern ced-ops-drop-spine = cedille-options.mk-options _ _ _ _ ff _ _ _ ff _ _
+pattern ced-ops-conv-arr = cedille-options.mk-options _ _ _ _ _ _ _ _ ff _ _
+pattern ced-ops-conv-abs = cedille-options.mk-options _ _ _ _ _ _ _ _ tt _ _
 
 drop-spine : cedille-options.options → {ed : exprd} → ctxt → ⟦ ed ⟧ → ⟦ ed ⟧
 drop-spine ops @ ced-ops-drop-spine = h


### PR DESCRIPTION
As title. I'm trying to compile cedille with Agda 2.6.1 (dev) and I found this.

With this fix, cedille type-checks fine, but compiles with this error:

```
~/git-repos/cedille/ial/int.agda:23,1-52
Failed to parse GHC pragma 'x = read x :: Int'
```

Right now I don't know how to fix this yet and I'll try later.