### PR TITLE
Fix to-string.agda to compile with Agda 2.6.1

### DIFF
--- a/src/to-string.agda
+++ b/src/to-string.agda
@@ -102,9 +102,9 @@ need-parens {TYPE} {_} (TpApp T tT) p lr = ~ is-arrow p && (~ is-type-level-app 
 need-parens {TYPE} {_} (TpLam x tk T) p lr = tt
 need-parens {KIND} {_} (KdAbs x tk k) p lr = ~ is-arrow p || is-left lr
 
-pattern ced-ops-drop-spine = cedille-options.options.mk-options _ _ _ _ ff _ _ _ ff _ _ _
-pattern ced-ops-conv-arr = cedille-options.options.mk-options _ _ _ _ _ _ _ _ ff _ _ _
-pattern ced-ops-conv-abs = cedille-options.options.mk-options _ _ _ _ _ _ _ _ tt _ _ _
+pattern ced-ops-drop-spine = cedille-options.mk-options _ _ _ _ ff _ _ _ ff _ _ _
+pattern ced-ops-conv-arr = cedille-options.mk-options _ _ _ _ _ _ _ _ ff _ _ _
+pattern ced-ops-conv-abs = cedille-options.mk-options _ _ _ _ _ _ _ _ tt _ _ _
 
 drop-spine : cedille-options.options → {ed : exprd} → ctxt → ⟦ ed ⟧ → ⟦ ed ⟧
 drop-spine ops @ ced-ops-drop-spine = h


### PR DESCRIPTION
While I don't have an older version of Agda to test with, the docs only mentioned 2.5.* that I saw, so I assume this is a compatibility issue with a newer Agda version.

Everything else worked fine with Agda 2.6.1.